### PR TITLE
fix: replace assert with RuntimeError check for SSH connection

### DIFF
--- a/fleet_platform/api/routes/webssh.py
+++ b/fleet_platform/api/routes/webssh.py
@@ -313,7 +313,8 @@ async def webssh_session(
             connect_kwargs["password"] = creds["ssh_password"]
             proxy._ssh_conn = await asyncssh.connect(**connect_kwargs)
 
-        assert proxy._ssh_conn is not None
+        if proxy._ssh_conn is None:
+            raise RuntimeError("SSH connection failed to establish")
         proxy._ssh_process = await proxy._ssh_conn.create_process(
             term_type="xterm-256color",
             request_pty=True,


### PR DESCRIPTION
## Fix Summary

Replaces `assert proxy._ssh_conn is not None` (line 316 of `webssh.py`) with an explicit `RuntimeError` check.

## Why

`assert` statements are stripped when Python runs with the `-O` (optimize) flag, making the connection check a no-op in production. This fix ensures the SSH connection failure is properly handled and raises a descriptive error.

## Changes

- Replace `assert proxy._ssh_conn is not None` with explicit `if` check and `RuntimeError` raise
- Fixes: #116