### PR TITLE
fix: error toasts persist, success/warning/info use distinct timings (closes #159)

### DIFF
--- a/frontend/src/stores/toastStore.ts
+++ b/frontend/src/stores/toastStore.ts
@@ -3,7 +3,14 @@ import { create } from 'zustand'
 export interface Toast {
   id: string
   message: string
-  type: 'success' | 'error' | 'info'
+  type: 'success' | 'error' | 'info' | 'warning'
+}
+
+const DISMISS_MS: Record<Toast['type'], number | null> = {
+  success: 3000,
+  info: 4000,
+  warning: 6000,
+  error: null, // no auto-dismiss — user must manually close
 }
 
 interface ToastState {
@@ -17,7 +24,10 @@ export const useToastStore = create<ToastState>()((set) => ({
   add: (message, type = 'success') => {
     const id = Math.random().toString(36).slice(2)
     set((s) => ({ toasts: [...s.toasts, { id, message, type }] }))
-    setTimeout(() => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })), 4000)
+    const delay = DISMISS_MS[type]
+    if (delay !== null) {
+      setTimeout(() => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })), delay)
+    }
   },
   remove: (id) => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
 }))

--- a/tests/unit/test_toast_dismiss_timing.py
+++ b/tests/unit/test_toast_dismiss_timing.py
@@ -1,0 +1,23 @@
+"""Unit tests for #159 — toast dismiss timing by type."""
+from pathlib import Path
+
+SRC = Path("frontend/src/stores/toastStore.ts").read_text()
+
+def test_error_toast_no_autodismiss():
+    """Error toasts must not auto-dismiss (no setTimeout for error type)."""
+    # The DISMISS_MS map must have null for error
+    assert "error: null" in SRC or "error:null" in SRC, (
+        "Error toasts must not auto-dismiss — null delay required"
+    )
+
+def test_success_uses_shorter_timeout():
+    """Success toasts should dismiss faster than the old 4000ms."""
+    assert "3000" in SRC, "Success toasts should use 3000ms dismiss"
+
+def test_warning_uses_longer_timeout():
+    """Warning toasts should stay longer than success."""
+    assert "6000" in SRC, "Warning toasts should use 6000ms dismiss"
+
+def test_dismiss_ms_map_present():
+    """DISMISS_MS lookup map must be present."""
+    assert "DISMISS_MS" in SRC, "toastStore must have DISMISS_MS type-to-delay map"


### PR DESCRIPTION
## Summary
- `toastStore.ts`: Added `DISMISS_MS` type-to-delay map: `success=3000ms`, `info=4000ms`, `warning=6000ms`, `error=null` (no auto-dismiss). Error toasts now persist until the user manually closes them.
- Also added `'warning'` to the `Toast` type union.

## Test plan
- [x] `pytest tests/unit/test_toast_dismiss_timing.py` — 4 passed
- [x] TypeScript build — 0 errors

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)