### PR TITLE
feat: role hierarchy in require_role — operator/admin satisfy viewer requirement (closes #151)

### DIFF
--- a/fleet_platform/core/auth.py
+++ b/fleet_platform/core/auth.py
@@ -134,11 +134,29 @@ async def get_current_user(
     return claims
 
 
+_ROLE_HIERARCHY = ["viewer", "operator", "admin"]
+
+
 def require_role(*roles: str):
-    """FastAPI dependency factory. Usage: Depends(require_role('admin', 'operator'))"""
+    """FastAPI dependency factory with role hierarchy.
+
+    require_role("viewer") → permits viewer, operator, admin
+    require_role("operator") → permits operator, admin
+    require_role("admin") → permits admin only
+
+    If multiple roles are passed, the MINIMUM required level is the
+    lowest-ranked role in the list.
+    """
+    # Compute the set of roles that satisfy the requirement:
+    # any role at or above the minimum required level
+    min_level = min(
+        (_ROLE_HIERARCHY.index(r) for r in roles if r in _ROLE_HIERARCHY),
+        default=len(_ROLE_HIERARCHY),
+    )
+    permitted = set(_ROLE_HIERARCHY[min_level:]) | set(roles)
 
     async def dependency(claims: dict = Depends(get_current_user)) -> dict:
-        if claims.get("role") not in roles:
+        if claims.get("role") not in permitted:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Role '{claims.get('role')}' cannot access this endpoint",

--- a/tests/unit/test_role_hierarchy.py
+++ b/tests/unit/test_role_hierarchy.py
@@ -1,0 +1,53 @@
+"""Unit tests for #151 — role hierarchy in require_role."""
+import pytest
+from fastapi import HTTPException
+
+
+def _make_claims(role: str) -> dict:
+    return {"sub": "user1", "role": role}
+
+
+@pytest.mark.asyncio
+async def test_viewer_can_access_viewer_endpoint():
+    from fleet_platform.core.auth import require_role
+    dep = require_role("viewer")
+    claims = await dep(claims=_make_claims("viewer"))
+    assert claims["role"] == "viewer"
+
+
+@pytest.mark.asyncio
+async def test_operator_can_access_viewer_endpoint():
+    """operator must be allowed on viewer-minimum endpoints (hierarchy)."""
+    from fleet_platform.core.auth import require_role
+    dep = require_role("viewer")
+    claims = await dep(claims=_make_claims("operator"))
+    assert claims["role"] == "operator"
+
+
+@pytest.mark.asyncio
+async def test_admin_can_access_operator_endpoint():
+    """admin must be allowed on operator-minimum endpoints."""
+    from fleet_platform.core.auth import require_role
+    dep = require_role("operator")
+    claims = await dep(claims=_make_claims("admin"))
+    assert claims["role"] == "admin"
+
+
+@pytest.mark.asyncio
+async def test_viewer_cannot_access_operator_endpoint():
+    """viewer must be denied on operator-minimum endpoints."""
+    from fleet_platform.core.auth import require_role
+    dep = require_role("operator")
+    with pytest.raises(HTTPException) as exc_info:
+        await dep(claims=_make_claims("viewer"))
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_operator_cannot_access_admin_endpoint():
+    """operator must be denied on admin-only endpoints."""
+    from fleet_platform.core.auth import require_role
+    dep = require_role("admin")
+    with pytest.raises(HTTPException) as exc_info:
+        await dep(claims=_make_claims("operator"))
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary
- `core/auth.py`: Added `_ROLE_HIERARCHY = ["viewer", "operator", "admin"]`. `require_role("viewer")` now permits viewer, operator, and admin. `require_role("operator")` permits operator and admin. `require_role("admin")` permits admin only.
- Eliminates the need to list all roles explicitly on every endpoint — adding a new role only requires updating `_ROLE_HIERARCHY`.

## Test plan
- [x] `pytest tests/unit/test_role_hierarchy.py` — 5 passed (viewer→viewer ✓, operator→viewer ✓, admin→operator ✓, viewer→operator 403 ✓, operator→admin 403 ✓)
- [x] `pytest tests/unit/ -q` — 418 passed, 0 regressions

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)