### PR TITLE
fix: Redis-based task deduplication for drift and grains refresh

### DIFF
--- a/fleet_platform/services/task_lock.py
+++ b/fleet_platform/services/task_lock.py
@@ -1,0 +1,51 @@
+"""Simple Redis-based task deduplication using SETNX."""
+import functools
+import logging
+from typing import Any
+
+import redis as sync_redis
+
+_log = logging.getLogger(__name__)
+_LOCK_TTL = 300  # 5 minutes — tasks must complete within this window
+
+
+def _get_sync_redis():
+    from fleet_platform.core.config import settings
+
+    return sync_redis.from_url(settings.redis_url, decode_responses=True)
+
+
+def unique_task(key_fn=None, ttl: int = _LOCK_TTL):
+    """Decorator that skips task execution if a lock with the same key exists.
+
+    Usage:
+        @unique_task(key_fn=lambda args, kwargs: f"compute_drift:{args[0]}")
+        @celery_app.task(...)
+        def compute_drift(node_id): ...
+
+    If key_fn is None, uses task name as lock key (for singleton tasks like
+    refresh_all_node_grains).
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            task_name = func.__name__
+            if key_fn is not None:
+                lock_key = f"task_lock:{key_fn(args, kwargs)}"
+            else:
+                lock_key = f"task_lock:{task_name}"
+
+            r = _get_sync_redis()
+            acquired = r.set(lock_key, "1", nx=True, ex=ttl)
+            if not acquired:
+                _log.debug("Skipping duplicate task %s (key=%s)", task_name, lock_key)
+                return None
+            try:
+                return func(*args, **kwargs)
+            finally:
+                r.delete(lock_key)
+
+        return wrapper
+
+    return decorator

--- a/fleet_platform/services/task_lock.py
+++ b/fleet_platform/services/task_lock.py
@@ -1,7 +1,6 @@
 """Simple Redis-based task deduplication using SETNX."""
 import functools
 import logging
-from typing import Any
 
 import redis as sync_redis
 

--- a/fleet_platform/workers/ansible_tasks.py
+++ b/fleet_platform/workers/ansible_tasks.py
@@ -19,6 +19,7 @@ from fleet_platform.models.bootstrap_run import BootstrapRun
 from fleet_platform.models.node import Node
 from fleet_platform.models.platform_setting import PlatformSetting
 from fleet_platform.services.ssh_keypair import get_controller_pubkey
+from fleet_platform.services.task_lock import unique_task
 from fleet_platform.workers.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
@@ -527,6 +528,7 @@ def collect_node_grains(self, node_id: str) -> dict:
                     pass
 
 
+@unique_task()  # singleton — one run at a time
 @celery_app.task(
     name="fleet_platform.workers.ansible_tasks.refresh_all_node_grains",
     queue="maintenance",

--- a/fleet_platform/workers/drift_tasks.py
+++ b/fleet_platform/workers/drift_tasks.py
@@ -10,9 +10,11 @@ from fleet_platform.models.facts import NodeFact
 from fleet_platform.models.node import Node
 from fleet_platform.services.baseline_loader import find_baseline_for_node_sync
 from fleet_platform.services.drift_engine import compute_drift as engine_compute_drift
+from fleet_platform.services.task_lock import unique_task
 from fleet_platform.workers.celery_app import celery_app
 
 
+@unique_task(key_fn=lambda args, kwargs: f"compute_drift:{args[0]}")
 @celery_app.task(
     name="fleet_platform.workers.drift_tasks.compute_drift",
     bind=True,

--- a/tests/unit/test_drift_task.py
+++ b/tests/unit/test_drift_task.py
@@ -10,13 +10,21 @@ def _make_mock_db():
     return db
 
 
+def _make_mock_redis():
+    """Return a mock Redis client that always acquires the lock."""
+    r = MagicMock()
+    r.set.return_value = True  # SETNX succeeds — lock acquired
+    return r
+
+
 def test_compute_drift_no_facts_returns_no_facts_status():
     from fleet_platform.workers.drift_tasks import compute_drift
 
     mock_db = _make_mock_db()
     mock_db.execute.return_value.scalar_one_or_none.return_value = None  # no NodeFact
 
-    with patch("fleet_platform.workers.drift_tasks.get_sync_db", return_value=mock_db):
+    with patch("fleet_platform.workers.drift_tasks.get_sync_db", return_value=mock_db), \
+         patch("fleet_platform.services.task_lock._get_sync_redis", return_value=_make_mock_redis()):
         result = compute_drift(str(uuid.uuid4()))
 
     assert result["status"] == "no_facts"
@@ -41,7 +49,8 @@ def test_compute_drift_no_baseline_returns_no_baseline_status():
     ]
     mock_db.execute.side_effect = execute_results
 
-    with patch("fleet_platform.workers.drift_tasks.get_sync_db", return_value=mock_db):
+    with patch("fleet_platform.workers.drift_tasks.get_sync_db", return_value=mock_db), \
+         patch("fleet_platform.services.task_lock._get_sync_redis", return_value=_make_mock_redis()):
         result = compute_drift(node_id)
 
     assert result["status"] == "no_baseline"
@@ -74,7 +83,8 @@ def test_compute_drift_writes_drift_record_and_returns_score():
     ]
     mock_db.execute.side_effect = execute_results
 
-    with patch("fleet_platform.workers.drift_tasks.get_sync_db", return_value=mock_db):
+    with patch("fleet_platform.workers.drift_tasks.get_sync_db", return_value=mock_db), \
+         patch("fleet_platform.services.task_lock._get_sync_redis", return_value=_make_mock_redis()):
         result = compute_drift(node_id)
 
     assert result["status"] == "computed"

--- a/tests/unit/test_task_lock.py
+++ b/tests/unit/test_task_lock.py
@@ -1,0 +1,83 @@
+"""Unit tests for #153 — Redis task deduplication."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fleet_platform.services.task_lock import unique_task
+
+
+def test_unique_task_runs_when_lock_acquired():
+    mock_redis = MagicMock()
+    mock_redis.set.return_value = True  # lock acquired
+
+    with patch("fleet_platform.services.task_lock._get_sync_redis", return_value=mock_redis):
+
+        @unique_task()
+        def my_task():
+            return "ran"
+
+        result = my_task()
+
+    assert result == "ran"
+    mock_redis.delete.assert_called_once()
+
+
+def test_unique_task_skips_when_lock_held():
+    mock_redis = MagicMock()
+    mock_redis.set.return_value = None  # lock already held
+
+    with patch("fleet_platform.services.task_lock._get_sync_redis", return_value=mock_redis):
+
+        @unique_task()
+        def my_task():
+            return "ran"
+
+        result = my_task()
+
+    assert result is None
+    mock_redis.delete.assert_not_called()
+
+
+def test_unique_task_releases_lock_on_exception():
+    mock_redis = MagicMock()
+    mock_redis.set.return_value = True
+
+    with patch("fleet_platform.services.task_lock._get_sync_redis", return_value=mock_redis):
+
+        @unique_task()
+        def failing_task():
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError):
+            failing_task()
+
+    mock_redis.delete.assert_called_once()
+
+
+def test_key_fn_produces_per_node_key():
+    mock_redis = MagicMock()
+    mock_redis.set.return_value = True
+
+    with patch("fleet_platform.services.task_lock._get_sync_redis", return_value=mock_redis):
+
+        @unique_task(key_fn=lambda args, kwargs: f"drift:{args[0]}")
+        def compute_drift(node_id):
+            return f"computed:{node_id}"
+
+        result = compute_drift("node-abc")
+
+    assert result == "computed:node-abc"
+    call_args = mock_redis.set.call_args
+    assert "drift:node-abc" in call_args[0][0]
+
+
+def test_drift_tasks_uses_unique_task():
+    with open("fleet_platform/workers/drift_tasks.py") as f:
+        src = f.read()
+    assert "unique_task" in src, "drift_tasks must use @unique_task for compute_drift"
+
+
+def test_health_tasks_uses_unique_task():
+    with open("fleet_platform/workers/ansible_tasks.py") as f:
+        src = f.read()
+    assert "unique_task" in src, "ansible_tasks must use @unique_task for refresh_all_node_grains"


### PR DESCRIPTION
## Summary
- New `fleet_platform/services/task_lock.py` with `unique_task` decorator using Redis SETNX
- `compute_drift` protected with per-node lock key to prevent duplicate drift computations
- `refresh_all_node_grains` protected as singleton (one run at a time)
- Lock always released in `finally` — no stale locks on exception

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)