### PR TITLE
fix: replace confirm() with styled ConfirmDialog, Salt state apply confirmation (closes #74 #76)

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'react'
+
+interface Props {
+  title: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  destructive?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmDialog({
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  destructive = false,
+  onConfirm,
+  onCancel,
+}: Props) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onCancel() }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onCancel])
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title">
+      <div className="bg-white rounded-xl shadow-2xl p-6 w-full max-w-sm mx-4 border border-gray-200">
+        <h2 id="confirm-dialog-title" className="text-base font-semibold text-gray-900 mb-2">{title}</h2>
+        <p className="text-sm text-gray-600 mb-5">{message}</p>
+        <div className="flex justify-end gap-3">
+          <button
+            autoFocus
+            onClick={onCancel}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            onClick={onConfirm}
+            className={`px-4 py-2 text-sm font-medium text-white rounded-lg transition-colors ${
+              destructive
+                ? 'bg-red-600 hover:bg-red-700'
+                : 'bg-brand-600 hover:bg-brand-700'
+            }`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/AlertsPage.tsx
+++ b/frontend/src/pages/AlertsPage.tsx
@@ -12,6 +12,7 @@ import {
 import { Skeleton } from '../components/Skeleton'
 import { ErrorState } from '../components/ErrorState'
 import { useToastStore } from '../stores/toastStore'
+import { ConfirmDialog } from '../components/ConfirmDialog'
 
 const EVENT_TYPES = [
   { value: 'node_offline', label: 'Node Offline' },
@@ -152,6 +153,8 @@ function AlertRules() {
     onError: (err: Error) => toast(err.message, 'error'),
   })
 
+  const [deletingRule, setDeletingRule] = useState<AlertRule | null>(null)
+
   const needsThreshold = form.event_type === 'drift_threshold' || form.event_type === 'cve_found'
 
   return (
@@ -270,11 +273,7 @@ function AlertRules() {
                   </td>
                   <td className="px-4 py-3 text-right">
                     <button
-                      onClick={() => {
-                        if (confirm(`Delete rule "${rule.name}"?`)) {
-                          deleteMut.mutate(rule.id)
-                        }
-                      }}
+                      onClick={() => setDeletingRule(rule)}
                       className="text-red-500 hover:text-red-700 text-xs font-medium"
                     >
                       Delete
@@ -286,6 +285,16 @@ function AlertRules() {
           </table>
         )}
       </div>
+      {deletingRule && (
+        <ConfirmDialog
+          title={`Delete rule "${deletingRule.name}"?`}
+          message="This alert rule will be permanently removed."
+          confirmLabel="Delete"
+          destructive
+          onConfirm={() => { deleteMut.mutate(deletingRule.id); setDeletingRule(null) }}
+          onCancel={() => setDeletingRule(null)}
+        />
+      )}
     </section>
   )
 }
@@ -302,6 +311,7 @@ function WebhookTargets() {
     type: 'slack',
     enabled: true,
   })
+  const [deletingWebhook, setDeletingWebhook] = useState<WebhookConfig | null>(null)
 
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ['alert-webhooks'],
@@ -455,11 +465,7 @@ function WebhookTargets() {
                         Test
                       </button>
                       <button
-                        onClick={() => {
-                          if (confirm(`Delete webhook "${wh.name}"?`)) {
-                            deleteMut.mutate(wh.id)
-                          }
-                        }}
+                        onClick={() => setDeletingWebhook(wh)}
                         className="text-red-500 hover:text-red-700 text-xs font-medium"
                       >
                         Delete
@@ -472,6 +478,16 @@ function WebhookTargets() {
           </table>
         )}
       </div>
+      {deletingWebhook && (
+        <ConfirmDialog
+          title={`Delete webhook "${deletingWebhook.name}"?`}
+          message="This webhook target will be permanently removed."
+          confirmLabel="Delete"
+          destructive
+          onConfirm={() => { deleteMut.mutate(deletingWebhook.id); setDeletingWebhook(null) }}
+          onCancel={() => setDeletingWebhook(null)}
+        />
+      )}
     </section>
   )
 }

--- a/frontend/src/pages/FleetDashboard.tsx
+++ b/frontend/src/pages/FleetDashboard.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from '../components/Skeleton'
 import { ErrorState } from '../components/ErrorState'
 import { Pagination } from '../components/Pagination'
 import { BootstrapModal } from './BootstrapModal'
+import { ConfirmDialog } from '../components/ConfirmDialog'
 import { formatDistanceToNow, differenceInDays, parseISO } from 'date-fns'
 import type { Node } from '../types'
 
@@ -571,6 +572,7 @@ export function FleetDashboard() {
   const [bulkScanning, setBulkScanning] = useState(false)
   const [bulkApplying, setBulkApplying] = useState(false)
   const [showSaltStateDropdown, setShowSaltStateDropdown] = useState(false)
+  const [saltStateConfirm, setSaltStateConfirm] = useState<string | null>(null)
   const [macosOnly, setMacosOnly] = useState(false)
 
   const user = useAuthStore((s) => s.user)
@@ -707,10 +709,14 @@ export function FleetDashboard() {
 
   async function bulkApplySaltState(state: string) {
     if (!state) return
+    setSaltStateConfirm(state)
+  }
+
+  async function confirmBulkApplySaltState() {
+    const state = saltStateConfirm
+    setSaltStateConfirm(null)
+    if (!state) return
     const selectedNodes = nodes?.items.filter((n) => selected.has(n.id)) ?? []
-    if (!window.confirm(`Apply state '${state}' to ${selectedNodes.length} node(s)? This will trigger a Salt state execution on selected nodes.`)) {
-      return
-    }
     setBulkApplying(true)
     const minionIds = selectedNodes.map((n) => n.minion_id)
     try {
@@ -1052,6 +1058,15 @@ export function FleetDashboard() {
       {showAddNode && <AddNodeModal onClose={() => setShowAddNode(false)} />}
       {editingNode && <EditNodeModal node={editingNode} onClose={() => setEditingNode(null)} />}
       {deletingNode && <DeleteNodeDialog node={deletingNode} onClose={() => setDeletingNode(null)} />}
+      {saltStateConfirm && (
+        <ConfirmDialog
+          title={`Apply state '${saltStateConfirm}'?`}
+          message={`This will trigger a Salt state execution on ${[...selected].length} selected node(s). This action cannot be undone.`}
+          confirmLabel="Apply State"
+          onConfirm={confirmBulkApplySaltState}
+          onCancel={() => setSaltStateConfirm(null)}
+        />
+      )}
       {showBulkDeleteConfirm && (
         <BulkDeleteConfirmModal
           count={selected.size}

--- a/frontend/src/pages/GroupExplorer.tsx
+++ b/frontend/src/pages/GroupExplorer.tsx
@@ -5,6 +5,7 @@ import { groupsApi } from '../api/groups'
 import { useToastStore } from '../stores/toastStore'
 import { Skeleton } from '../components/Skeleton'
 import { ErrorState } from '../components/ErrorState'
+import { ConfirmDialog } from '../components/ConfirmDialog'
 import { Pagination } from '../components/Pagination'
 import { format } from 'date-fns'
 
@@ -17,6 +18,8 @@ export function GroupExplorer() {
   const [predicate, setPredicate] = useState('{"and": []}')
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [bulkDeleting, setBulkDeleting] = useState(false)
+  const [bulkDeleteConfirm, setBulkDeleteConfirm] = useState(false)
+  const [deletingGroup, setDeletingGroup] = useState<{ id: string; name: string } | null>(null)
   const qc = useQueryClient()
   const toast = useToastStore((s) => s.add)
 
@@ -65,9 +68,14 @@ export function GroupExplorer() {
     setSelected(next)
   }
 
-  async function bulkDelete() {
+  function bulkDelete() {
+    if (selected.size === 0) return
+    setBulkDeleteConfirm(true)
+  }
+
+  async function confirmBulkDelete() {
+    setBulkDeleteConfirm(false)
     const count = selected.size
-    if (!confirm(`Delete ${count} group${count === 1 ? '' : 's'}? This cannot be undone.`)) return
     setBulkDeleting(true)
     await Promise.all([...selected].map((id) => groupsApi.delete(id)))
     setBulkDeleting(false)
@@ -203,11 +211,7 @@ export function GroupExplorer() {
                     <td className="px-4 py-3 text-gray-500">{format(new Date(g.created_at), 'PP')}</td>
                     <td className="px-4 py-3 text-right">
                       <button
-                        onClick={() => {
-                          if (confirm(`Delete group "${g.name}"? This cannot be undone.`)) {
-                            deleteMutation.mutate(g.id)
-                          }
-                        }}
+                        onClick={() => setDeletingGroup({ id: g.id, name: g.name })}
                         disabled={deleteMutation.isPending || bulkDeleting}
                         className="text-xs text-red-500 hover:text-red-700 font-medium disabled:opacity-50"
                       >
@@ -222,6 +226,26 @@ export function GroupExplorer() {
           </>
         )}
       </div>
+      {bulkDeleteConfirm && (
+        <ConfirmDialog
+          title={`Delete ${selected.size} group${selected.size === 1 ? '' : 's'}?`}
+          message="This cannot be undone. All selected groups will be permanently deleted."
+          confirmLabel="Delete"
+          destructive
+          onConfirm={confirmBulkDelete}
+          onCancel={() => setBulkDeleteConfirm(false)}
+        />
+      )}
+      {deletingGroup && (
+        <ConfirmDialog
+          title={`Delete group "${deletingGroup.name}"?`}
+          message="This cannot be undone."
+          confirmLabel="Delete"
+          destructive
+          onConfirm={() => { deleteMutation.mutate(deletingGroup.id); setDeletingGroup(null) }}
+          onCancel={() => setDeletingGroup(null)}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/NodeDetail.tsx
+++ b/frontend/src/pages/NodeDetail.tsx
@@ -18,6 +18,7 @@ import { formatGrainKey } from './DriftExplorer'
 import { Skeleton } from '../components/Skeleton'
 import { ErrorState } from '../components/ErrorState'
 import { Pagination } from '../components/Pagination'
+import { ConfirmDialog } from '../components/ConfirmDialog'
 import { SshTabBar } from '../components/ssh/SshTabBar'
 import { MultiSessionTerminal } from '../components/ssh/MultiSessionTerminal'
 import type { SshTab } from '../components/ssh/SshTabBar'
@@ -148,6 +149,7 @@ function IOSTabPanel({
   qc: ReturnType<typeof useQueryClient>
   toast: (message: string, type?: 'success' | 'error' | 'info') => void
 }) {
+  const [deletingCert, setDeletingCert] = useState<string | null>(null)
   const agent = iosDetail?.jenkins_agent ?? null
   const certs = iosDetail?.certificates ?? []
 
@@ -318,11 +320,7 @@ function IOSTabPanel({
                       </td>
                       <td className="px-4 py-2 text-right">
                         <button
-                          onClick={() => {
-                            if (confirm('Delete this certificate?')) {
-                              deleteCertMutation.mutate(cert.id)
-                            }
-                          }}
+                          onClick={() => setDeletingCert(cert.id)}
                           disabled={deleteCertMutation.isPending}
                           className="text-xs text-red-500 hover:text-red-700 font-medium disabled:opacity-50"
                         >
@@ -337,6 +335,16 @@ function IOSTabPanel({
           </div>
         )}
       </div>
+      {deletingCert && (
+        <ConfirmDialog
+          title="Delete this certificate?"
+          message="This certificate will be permanently removed from the node."
+          confirmLabel="Delete"
+          destructive
+          onConfirm={() => { deleteCertMutation.mutate(deletingCert); setDeletingCert(null) }}
+          onCancel={() => setDeletingCert(null)}
+        />
+      )}
     </div>
   )
 }
@@ -377,6 +385,7 @@ export function NodeDetail() {
   const [secretValue, setSecretValue] = useState('')
   const [secretDesc, setSecretDesc] = useState('')
   const [secretShowValue, setSecretShowValue] = useState(false)
+  const [deletingSecretKey, setDeletingSecretKey] = useState<string | null>(null)
   // iOS tab state
   const [showAddCert, setShowAddCert] = useState(false)
   const [showJenkinsConfigure, setShowJenkinsConfigure] = useState(false)
@@ -1598,10 +1607,7 @@ export function NodeDetail() {
                       </td>
                       <td className="px-4 py-3 text-right">
                         <button
-                          onClick={() => {
-                            if (!window.confirm('Delete this secret? This cannot be undone.')) return
-                            deleteSecretMutation.mutate(s.key)
-                          }}
+                          onClick={() => setDeletingSecretKey(s.key)}
                           disabled={deleteSecretMutation.isPending}
                           className="text-xs text-red-600 hover:text-red-700 font-medium disabled:opacity-50"
                         >
@@ -1764,6 +1770,16 @@ export function NodeDetail() {
             />
           )}
         </div>
+      )}
+      {deletingSecretKey && (
+        <ConfirmDialog
+          title="Delete this secret?"
+          message="This secret will be permanently removed from the node. This cannot be undone."
+          confirmLabel="Delete"
+          destructive
+          onConfirm={() => { deleteSecretMutation.mutate(deletingSecretKey); setDeletingSecretKey(null) }}
+          onCancel={() => setDeletingSecretKey(null)}
+        />
       )}
     </div>
   )

--- a/tests/unit/test_ux_confirm_dialogs_b14.py
+++ b/tests/unit/test_ux_confirm_dialogs_b14.py
@@ -1,0 +1,32 @@
+"""Unit tests for #74 (bulk Salt confirm) and #76 (replace confirm() with modal)."""
+import re
+from pathlib import Path
+
+DASHBOARD = Path("frontend/src/pages/FleetDashboard.tsx").read_text()
+GROUP = Path("frontend/src/pages/GroupExplorer.tsx").read_text()
+ALERTS = Path("frontend/src/pages/AlertsPage.tsx").read_text()
+NODE = Path("frontend/src/pages/NodeDetail.tsx").read_text()
+CONFIRM_COMPONENT = Path("frontend/src/components/ConfirmDialog.tsx").read_text()
+
+
+def test_no_bare_confirm_calls_remain():
+    """No production code should use bare confirm() or window.confirm()."""
+    for name, src in [("FleetDashboard", DASHBOARD), ("GroupExplorer", GROUP),
+                      ("AlertsPage", ALERTS), ("NodeDetail", NODE)]:
+        assert "window.confirm(" not in src, f"{name} must not use window.confirm()"
+        # bare confirm( — only in comments or strings is OK
+        bare = re.findall(r'(?<!\w)confirm\s*\(', src)
+        assert not bare, f"{name} has bare confirm() calls: {bare}"
+
+
+def test_bulk_salt_state_uses_confirm_dialog():
+    assert "ConfirmDialog" in DASHBOARD, "FleetDashboard must use ConfirmDialog for Salt state apply"
+    assert "saltStateConfirm" in DASHBOARD or "confirmBulkApply" in DASHBOARD, (
+        "FleetDashboard must have confirm state for bulk Salt apply"
+    )
+
+
+def test_confirm_dialog_component_exists():
+    assert "role=\"dialog\"" in CONFIRM_COMPONENT, "ConfirmDialog must have role=dialog"
+    assert "aria-modal" in CONFIRM_COMPONENT, "ConfirmDialog must have aria-modal"
+    assert "Escape" in CONFIRM_COMPONENT, "ConfirmDialog must handle Escape key"


### PR DESCRIPTION
## Summary
- Closes #74: Bulk Salt state apply now shows a `ConfirmDialog` with state name and node count before executing — no more fire-and-forget
- Closes #76: All 6 bare `confirm()`/`window.confirm()` calls replaced with shared `ConfirmDialog` component across GroupExplorer, AlertsPage, and NodeDetail

## Changes
- `frontend/src/components/ConfirmDialog.tsx` — new reusable modal: `role="dialog"`, `aria-modal`, Escape key, `destructive` prop for red buttons, autoFocus Cancel
- `frontend/src/pages/FleetDashboard.tsx` — `saltStateConfirm` state gates bulk apply
- `frontend/src/pages/GroupExplorer.tsx` — group bulk delete + per-group delete use ConfirmDialog
- `frontend/src/pages/AlertsPage.tsx` — alert rule + webhook delete use ConfirmDialog  
- `frontend/src/pages/NodeDetail.tsx` — certificate + secret delete use ConfirmDialog
- `tests/unit/test_ux_confirm_dialogs_b14.py` — 3 tests

## Test plan
- [ ] Unit: `pytest tests/unit/test_ux_confirm_dialogs_b14.py` — 3 tests pass
- [ ] Manual: Fleet Dashboard → select nodes → pick Salt state → dialog appears with state name + count
- [ ] Manual: Groups → delete group → styled modal, not browser confirm()
- [ ] Manual: Alerts → delete rule → styled modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)