### PR TITLE
fix: OIDC exception logging, SSO error banner on login page (closes #67 #72)

### DIFF
--- a/fleet_platform/api/routes/oidc.py
+++ b/fleet_platform/api/routes/oidc.py
@@ -1,6 +1,7 @@
 """OIDC SSO endpoints — login redirect, callback, one-time exchange."""
 
 import json
+import logging
 import secrets
 
 import redis.asyncio as aioredis
@@ -21,6 +22,8 @@ from fleet_platform.services.platform_settings_svc import (
 )
 
 router = APIRouter(prefix="/api/v1/auth/oidc")
+
+logger = logging.getLogger(__name__)
 
 _STATE_TTL = 300  # 5 minutes
 _STATE_PREFIX = "oidc:state:"
@@ -58,6 +61,7 @@ async def oidc_login(
     try:
         discovery = await oidc_svc.discover(issuer)
     except Exception:
+        logger.exception("OIDC login initiation failed")
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="OIDC discovery failed")
 
     redirect_uri = f"{app_settings.frontend_origin.rstrip('/')}/auth/callback"
@@ -91,6 +95,7 @@ async def oidc_callback(
     try:
         discovery = await oidc_svc.discover(issuer)
     except Exception:
+        logger.exception("OIDC callback failed")
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="OIDC discovery failed")
 
     redirect_uri = f"{app_settings.frontend_origin.rstrip('/')}/auth/callback"
@@ -103,6 +108,7 @@ async def oidc_callback(
             redirect_uri=redirect_uri,
         )
     except Exception:
+        logger.exception("OIDC token exchange failed")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Token exchange failed")
 
     # Verify the ID token signature using the IdP's JWKS (fix #79)
@@ -114,6 +120,7 @@ async def oidc_callback(
             client_id=client_id,
         )
     except Exception:
+        logger.exception("OIDC userinfo fetch failed")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="ID token verification failed")
 
     email = claims.get("email", "")

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { authApi } from '../api/auth'
 import { useAuthStore } from '../stores/authStore'
 
@@ -12,8 +12,8 @@ export function LoginPage() {
   const [oidcEnabled, setOidcEnabled] = useState(false)
   const navigate = useNavigate()
   const setUser = useAuthStore((s) => s.setUser)
-
-  const oidcError = new URLSearchParams(window.location.search).get('error')
+  const [searchParams] = useSearchParams()
+  const [ssoError, setSsoError] = useState(!!searchParams.get('error'))
 
   useEffect(() => {
     authApi.getOidcConfig().then((cfg) => setOidcEnabled(cfg.enabled)).catch(() => {})
@@ -78,9 +78,12 @@ export function LoginPage() {
           <h1 className="text-white text-2xl font-bold mb-1">Sign in</h1>
           <p className="text-white/35 text-sm mb-8">Enter your credentials to access the fleet dashboard</p>
 
-          {oidcError && (
-            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
-              Single sign-on failed. Please try again or sign in with email and password.
+          {ssoError && (
+            <div className="mb-4 flex items-start gap-3 p-4 bg-red-50 border border-red-200 rounded-lg">
+              <span className="text-red-600 text-sm font-medium flex-1">
+                Single sign-on failed. Please try again or sign in with email and password.
+              </span>
+              <button onClick={() => setSsoError(false)} className="text-red-400 hover:text-red-600 text-lg leading-none">✕</button>
             </div>
           )}
 

--- a/tests/unit/test_oidc_logging_error_b15.py
+++ b/tests/unit/test_oidc_logging_error_b15.py
@@ -1,0 +1,36 @@
+"""Unit tests for #67 (OIDC exception logging) and #72 (login SSO error banner)."""
+from pathlib import Path
+
+OIDC = Path("fleet_platform/api/routes/oidc.py").read_text()
+LOGIN = Path("frontend/src/pages/LoginPage.tsx").read_text()
+
+
+def test_oidc_handlers_log_exceptions():
+    """All OIDC exception handlers must call logger.exception."""
+    assert "logger.exception" in OIDC, (
+        "OIDC route handlers must call logger.exception in catch blocks"
+    )
+    count = OIDC.count("logger.exception")
+    assert count >= 2, f"Expected at least 2 logger.exception calls, found {count}"
+
+
+def test_oidc_has_logger_defined():
+    assert "getLogger" in OIDC, "OIDC module must define a module-level logger"
+
+
+def test_login_page_reads_error_param():
+    assert "searchParams" in LOGIN or "useSearchParams" in LOGIN, (
+        "LoginPage must use useSearchParams to read error param"
+    )
+    assert "oidc_failed" in LOGIN or "ssoError" in LOGIN or "error" in LOGIN, (
+        "LoginPage must handle the OIDC error query param"
+    )
+
+
+def test_login_page_has_dismissible_banner():
+    assert "setSsoError" in LOGIN or "setError" in LOGIN, (
+        "LoginPage must have dismissible error state"
+    )
+    assert "Single sign-on failed" in LOGIN or "sign-on" in LOGIN.lower(), (
+        "LoginPage must show a human-readable SSO error message"
+    )


### PR DESCRIPTION
## Summary
- Closes #67: All 4 bare `except Exception:` blocks in `oidc.py` now call `logger.exception()` with operation-specific messages — OIDC provider outages are no longer silent
- Closes #72: `LoginPage` reads `?error=` query param and shows a dismissible "Single sign-on failed" banner when OIDC callback redirects with an error

## Changes
- `fleet_platform/api/routes/oidc.py` — module-level logger + `logger.exception()` in all 4 catch blocks
- `frontend/src/pages/LoginPage.tsx` — `useSearchParams` + dismissible SSO error banner
- `tests/unit/test_oidc_logging_error_b15.py` — 4 tests

## Test plan
- [ ] Unit: `pytest tests/unit/test_oidc_logging_error_b15.py` — 4 tests pass
- [ ] Manual: Trigger OIDC failure → redirect to `/login?error=oidc_failed` → banner shown, dismissible with ✕

🤖 Generated with [Claude Code](https://claude.com/claude-code)