### PR TITLE
fix: log swallowed exceptions in ansible_tasks and webssh (closes #63 #66)

### DIFF
--- a/fleet_platform/api/routes/webssh.py
+++ b/fleet_platform/api/routes/webssh.py
@@ -13,6 +13,7 @@ Security model:
 """
 import asyncio
 import base64
+import logging
 import uuid
 from datetime import UTC, datetime
 
@@ -31,6 +32,8 @@ from fleet_platform.core.auth import (
 from fleet_platform.db.session import AsyncSessionLocal
 from fleet_platform.models.node import Node
 from fleet_platform.models.ssh_session import SecurityEvent, SessionRecording, SSHSession
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/ssh")
 
@@ -70,8 +73,8 @@ class SSHProxySession:
             await self._flush_recording()
         try:
             await self.ws.send_text(text)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("send_to_browser: ws send failed (client may have disconnected): %s", e)
 
     async def _flush_recording(self) -> None:
         if not self._recording_chunks:
@@ -137,13 +140,13 @@ class SSHProxySession:
         if self._ssh_process:
             try:
                 self._ssh_process.close()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("close: SSH process close failed: %s", e)
         if self._ssh_conn:
             try:
                 self._ssh_conn.close()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("close: SSH connection close failed: %s", e)
         # Update session end
         async with AsyncSessionLocal() as db:
             session = await db.get(SSHSession, self.session_id)
@@ -308,8 +311,8 @@ async def webssh_session(
                     if isinstance(chunk, str):
                         chunk = chunk.encode()
                     await proxy.send_to_browser(chunk)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("read_ssh: SSH stdout pump ended: %s", e)
 
         asyncio.create_task(read_ssh())
 

--- a/fleet_platform/workers/ansible_tasks.py
+++ b/fleet_platform/workers/ansible_tasks.py
@@ -78,7 +78,8 @@ def _get_node_credentials(node) -> tuple[str, str, str]:
             password = decrypt_secret(node.ssh_password_enc)
         except Exception as e:
             logger.warning(
-                "_get_node_credentials: failed to decrypt ssh_password_enc for node_id=%s — using empty password. Cause: %s",
+                "_get_node_credentials: failed to decrypt ssh_password_enc"
+                " for node_id=%s — using empty password. Cause: %s",
                 node.id,
                 e,
             )

--- a/fleet_platform/workers/ansible_tasks.py
+++ b/fleet_platform/workers/ansible_tasks.py
@@ -76,8 +76,12 @@ def _get_node_credentials(node) -> tuple[str, str, str]:
     if node.ssh_password_enc:
         try:
             password = decrypt_secret(node.ssh_password_enc)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(
+                "_get_node_credentials: failed to decrypt ssh_password_enc for node_id=%s — using empty password. Cause: %s",
+                node.id,
+                e,
+            )
     return user, password, auth_mode
 
 

--- a/tests/unit/test_silent_exceptions_logging_b19.py
+++ b/tests/unit/test_silent_exceptions_logging_b19.py
@@ -2,8 +2,6 @@
 import logging
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 class TestGetNodeCredentialsLogging:
     """Tests for _get_node_credentials in ansible_tasks.py (issue #63)."""
@@ -68,4 +66,27 @@ class TestWebSSHLogger:
         )
         assert isinstance(webssh_module.logger, logging.Logger), (
             "webssh.logger must be a logging.Logger instance"
+        )
+
+    def test_webssh_send_to_browser_logs_on_send_failure(self, caplog):
+        """logger.debug fires when ws.send_text raises."""
+        import asyncio
+        import uuid
+        from unittest.mock import AsyncMock, MagicMock
+
+        from fleet_platform.api.routes.webssh import SSHProxySession
+
+        ws = MagicMock()
+        ws.send_text = AsyncMock(side_effect=Exception("connection reset"))
+        proxy = SSHProxySession(ws=ws, session_id=uuid.uuid4())
+        # Stub out _flush_recording so it doesn't try to hit the DB
+        proxy._flush_recording = AsyncMock()
+
+        with caplog.at_level(logging.DEBUG, logger="fleet_platform.api.routes.webssh"):
+            asyncio.get_event_loop().run_until_complete(
+                proxy.send_to_browser(b"hello")
+            )
+
+        assert any("send_to_browser" in r.message for r in caplog.records), (
+            "logger.debug must fire in send_to_browser when ws.send_text raises"
         )

--- a/tests/unit/test_silent_exceptions_logging_b19.py
+++ b/tests/unit/test_silent_exceptions_logging_b19.py
@@ -1,0 +1,71 @@
+"""Tests for silent exception logging fixes — issues #63 and #66."""
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestGetNodeCredentialsLogging:
+    """Tests for _get_node_credentials in ansible_tasks.py (issue #63)."""
+
+    def test_get_node_credentials_logs_on_decrypt_failure(self, caplog):
+        """Decrypt failure must emit a WARNING log — not silently swallow."""
+        from fleet_platform.workers.ansible_tasks import _get_node_credentials
+
+        node = MagicMock()
+        node.id = "test-node-id-123"
+        node.ssh_username = ""
+        node.ssh_password_enc = "bad-encrypted-value"
+        node.ssh_auth_mode = "password"
+
+        with patch(
+            "fleet_platform.services.platform_settings_svc.decrypt_secret",
+            side_effect=Exception("bad key"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="fleet_platform.workers.ansible_tasks"):
+                result = _get_node_credentials(node)
+
+        # Must not crash
+        assert result is not None
+        # Must emit at least one WARNING
+        assert any(
+            r.levelno == logging.WARNING for r in caplog.records
+        ), "Expected a WARNING log when decryption fails"
+        # Log must mention the node id
+        warning_text = " ".join(r.message for r in caplog.records if r.levelno == logging.WARNING)
+        assert "test-node-id-123" in warning_text
+
+    def test_get_node_credentials_returns_empty_password_on_failure(self):
+        """On decrypt failure, password must be empty string — no crash."""
+        from fleet_platform.workers.ansible_tasks import _get_node_credentials
+
+        node = MagicMock()
+        node.id = "test-node-id-456"
+        node.ssh_username = ""
+        node.ssh_password_enc = "bad-encrypted-value"
+        node.ssh_auth_mode = "password"
+
+        with patch(
+            "fleet_platform.services.platform_settings_svc.decrypt_secret",
+            side_effect=Exception("bad key"),
+        ):
+            user, password, auth_mode = _get_node_credentials(node)
+
+        assert user == ""
+        assert password == ""
+        assert auth_mode == "password"
+
+
+class TestWebSSHLogger:
+    """Tests for logger in webssh.py (issue #66)."""
+
+    def test_webssh_logger_exists(self):
+        """webssh module must expose a module-level logger instance."""
+        import fleet_platform.api.routes.webssh as webssh_module
+
+        assert hasattr(webssh_module, "logger"), (
+            "fleet_platform.api.routes.webssh must have a module-level 'logger' attribute"
+        )
+        assert isinstance(webssh_module.logger, logging.Logger), (
+            "webssh.logger must be a logging.Logger instance"
+        )


### PR DESCRIPTION
## Summary
- ansible_tasks: log Fernet decryption failure with node_id and cause at WARNING level so operators see it
- webssh: add module logger, debug-log all swallowed connection/close exceptions (send_to_browser, close SSH process, close SSH conn, read_ssh stdout pump)

## Test plan
- [x] Unit: test_get_node_credentials_logs_on_decrypt_failure — verifies WARNING is emitted with node_id
- [x] Unit: test_webssh_logger_exists — verifies webssh module exposes a logging.Logger instance
- [x] Unit: test_get_node_credentials_returns_empty_password_on_failure — verifies no crash and empty password returned

Closes #63 #66

🤖 Generated with Claude Code