### PR TITLE
fix: prevent DB pool exhaustion in collect_fleet_health (closes #124)

### DIFF
--- a/fleet_platform/workers/health_tasks.py
+++ b/fleet_platform/workers/health_tasks.py
@@ -31,7 +31,15 @@ def collect_fleet_health() -> dict:
     Runs as Celery beat task every 15 minutes. Also triggerable on-demand via API.
     Nodes are processed in batches of BATCH_SIZE with a short pause between
     batches to avoid thundering-herd on the Salt master.
+
+    Two-session design (fixes #124):
+    - Session 1 (read): loads online nodes, then closes immediately.
+    - Salt metric collection runs with NO open DB connection.
+    - Session 2 (write): persists snapshots after all Salt calls complete.
+    This prevents a connection pool slot being held for the entire Salt run
+    (which can take 30 s+ per batch with retries).
     """
+    # --- Session 1: read online nodes, close before any Salt calls ----------
     with get_sync_db() as db:
         nodes = db.execute(
             select(Node).where(Node.status == "online")
@@ -41,30 +49,39 @@ def collect_fleet_health() -> dict:
             _log.info("collect_fleet_health: no online nodes, skipping")
             return {"collected": 0}
 
-        node_by_minion = {n.minion_id: n for n in nodes}
-        minion_ids = list(node_by_minion.keys())
+        # Copy only primitive data out of the session-bound ORM objects so
+        # they remain usable after the session closes (detached ORM instances
+        # would raise DetachedInstanceError).
+        node_by_minion: dict[str, dict] = {
+            n.minion_id: {"id": n.id, "minion_id": n.minion_id} for n in nodes
+        }
+    # Session 1 is now closed — connection pool slot released.
 
-        _log.info(
-            "collect_fleet_health: collecting from %d nodes in batches of %d",
-            len(minion_ids),
-            BATCH_SIZE,
-        )
+    minion_ids = list(node_by_minion.keys())
+    _log.info(
+        "collect_fleet_health: collecting from %d nodes in batches of %d",
+        len(minion_ids),
+        BATCH_SIZE,
+    )
 
-        merged: dict[str, dict] = {}
-        for i in range(0, len(minion_ids), BATCH_SIZE):
-            batch = minion_ids[i : i + BATCH_SIZE]
-            batch_metrics = salt_maintenance_svc.collect_all_metrics(batch)
-            merged.update(batch_metrics)
-            if i + BATCH_SIZE < len(minion_ids):
-                time.sleep(BATCH_DELAY_S)
+    # --- Salt calls: no DB session open ------------------------------------
+    merged: dict[str, dict] = {}
+    for i in range(0, len(minion_ids), BATCH_SIZE):
+        batch = minion_ids[i : i + BATCH_SIZE]
+        batch_metrics = salt_maintenance_svc.collect_all_metrics(batch)
+        merged.update(batch_metrics)
+        if i + BATCH_SIZE < len(minion_ids):
+            time.sleep(BATCH_DELAY_S)
 
-        count = 0
+    # --- Session 2: persist snapshots -------------------------------------
+    count = 0
+    with get_sync_db() as db:
         for minion_id, metrics in merged.items():
-            node = node_by_minion.get(minion_id)
-            if node is None:
+            node_info = node_by_minion.get(minion_id)
+            if node_info is None:
                 continue
             snapshot = NodeHealthSnapshot(
-                node_id=node.id,
+                node_id=node_info["id"],
                 minion_id=minion_id,
                 disk_root_used_gb=metrics.get("disk_root_used_gb"),
                 disk_root_total_gb=metrics.get("disk_root_total_gb"),
@@ -86,10 +103,10 @@ def collect_fleet_health() -> dict:
             )
             db.add(snapshot)
             count += 1
-
         db.commit()
-        _log.info("collect_fleet_health: stored %d snapshots", count)
-        return {"collected": count}
+
+    _log.info("collect_fleet_health: stored %d snapshots", count)
+    return {"collected": count}
 
 
 @celery_app.task(

--- a/tests/unit/test_health_db_session_b20.py
+++ b/tests/unit/test_health_db_session_b20.py
@@ -1,0 +1,194 @@
+# tests/unit/test_health_db_session_b20.py
+"""
+Tests for #124: collect_fleet_health must close the DB session before making
+any Salt subprocess calls, so the connection pool slot is not held for the
+entire (potentially 30s+) Salt collection window.
+"""
+import uuid
+from contextlib import contextmanager
+from unittest.mock import MagicMock, call, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_node(minion_id: str):
+    node = MagicMock()
+    node.id = uuid.uuid4()
+    node.minion_id = minion_id
+    return node
+
+
+def _fake_metrics(*minion_ids: str) -> dict:
+    return {
+        mid: {
+            "disk_root_used_gb": 50.0,
+            "disk_root_total_gb": 256.0,
+            "disk_root_pct": 20,
+            "disk_root_inodes_pct": 1,
+            "mem_total_gb": 16.0,
+            "mem_available_gb": 8.0,
+            "mem_used_pct": 50,
+            "cpu_load_1m": 0.5,
+            "cpu_load_5m": 0.4,
+            "cpu_load_15m": 0.3,
+            "uptime_seconds": 86400,
+            "gpu_name": None,
+            "gpu_vram_mb": None,
+            "cpu_power_mw": None,
+            "gpu_power_mw": None,
+            "thermal_pressure": None,
+            "error": None,
+        }
+        for mid in minion_ids
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Session 1 is CLOSED before collect_all_metrics is called
+# ---------------------------------------------------------------------------
+
+def test_collect_fleet_health_closes_session_before_salt_calls():
+    """Session 1 must be fully closed (exited) before Salt metric collection."""
+    from fleet_platform.workers.health_tasks import collect_fleet_health
+
+    session_1_exited_before_salt = []  # mutable flag captured in closure
+
+    # Track whether session 1's __exit__ has been called when Salt runs
+    session_1_exit_called = [False]
+
+    class _TrackingSession:
+        """Context manager that records when it is exited."""
+
+        def __init__(self):
+            self.mock = MagicMock()
+
+        def __enter__(self):
+            return self.mock
+
+        def __exit__(self, *args):
+            session_1_exit_called[0] = True
+            return False
+
+    class _WriteSession:
+        def __init__(self):
+            self.mock = MagicMock()
+
+        def __enter__(self):
+            return self.mock
+
+        def __exit__(self, *args):
+            return False
+
+    read_session = _TrackingSession()
+    write_session = _WriteSession()
+
+    node = _make_node("mac-mini-01")
+    read_session.mock.execute.return_value.scalars.return_value.all.return_value = [node]
+
+    call_count = [0]
+
+    def fake_get_sync_db():
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return read_session
+        return write_session
+
+    def fake_collect_all_metrics(batch):
+        # Record whether session 1 was already exited at the time Salt is called
+        session_1_exited_before_salt.append(session_1_exit_called[0])
+        return _fake_metrics(*batch)
+
+    with (
+        patch("fleet_platform.workers.health_tasks.get_sync_db", side_effect=fake_get_sync_db),
+        patch(
+            "fleet_platform.workers.health_tasks.salt_maintenance_svc.collect_all_metrics",
+            side_effect=fake_collect_all_metrics,
+        ),
+    ):
+        result = collect_fleet_health()
+
+    assert result == {"collected": 1}
+    # Salt was called at least once
+    assert len(session_1_exited_before_salt) >= 1, "collect_all_metrics was never called"
+    # Session 1 must have been closed before every Salt call
+    assert all(session_1_exited_before_salt), (
+        "Session 1 was still open when collect_all_metrics was called — "
+        "this holds a connection pool slot during the entire Salt run"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Exactly 2 DB sessions when nodes exist
+# ---------------------------------------------------------------------------
+
+def test_collect_fleet_health_uses_two_sessions():
+    """When online nodes are found, exactly 2 get_sync_db() calls must be made."""
+    from fleet_platform.workers.health_tasks import collect_fleet_health
+
+    node = _make_node("mac-mini-01")
+
+    read_mock = MagicMock()
+    read_mock.__enter__ = MagicMock(return_value=read_mock)
+    read_mock.__exit__ = MagicMock(return_value=False)
+    read_mock.execute.return_value.scalars.return_value.all.return_value = [node]
+
+    write_mock = MagicMock()
+    write_mock.__enter__ = MagicMock(return_value=write_mock)
+    write_mock.__exit__ = MagicMock(return_value=False)
+
+    sessions = [read_mock, write_mock]
+    call_count = [0]
+
+    def fake_get_sync_db():
+        idx = call_count[0]
+        call_count[0] += 1
+        return sessions[idx]
+
+    with (
+        patch("fleet_platform.workers.health_tasks.get_sync_db", side_effect=fake_get_sync_db),
+        patch(
+            "fleet_platform.workers.health_tasks.salt_maintenance_svc.collect_all_metrics",
+            return_value=_fake_metrics("mac-mini-01"),
+        ),
+    ):
+        result = collect_fleet_health()
+
+    assert result == {"collected": 1}
+    assert call_count[0] == 2, (
+        f"Expected exactly 2 DB sessions (read + write), got {call_count[0]}"
+    )
+    # Read session should NOT have db.add called on it
+    read_mock.add.assert_not_called()
+    # Write session should have db.add called once and db.commit once
+    write_mock.add.assert_called_once()
+    write_mock.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Early return (no online nodes) uses exactly 1 session
+# ---------------------------------------------------------------------------
+
+def test_collect_fleet_health_no_nodes_uses_one_session():
+    """When there are no online nodes, only 1 DB session is opened (early return)."""
+    from fleet_platform.workers.health_tasks import collect_fleet_health
+
+    read_mock = MagicMock()
+    read_mock.__enter__ = MagicMock(return_value=read_mock)
+    read_mock.__exit__ = MagicMock(return_value=False)
+    read_mock.execute.return_value.scalars.return_value.all.return_value = []
+
+    call_count = [0]
+
+    def fake_get_sync_db():
+        call_count[0] += 1
+        return read_mock
+
+    with patch("fleet_platform.workers.health_tasks.get_sync_db", side_effect=fake_get_sync_db):
+        result = collect_fleet_health()
+
+    assert result == {"collected": 0}
+    assert call_count[0] == 1, (
+        f"Expected exactly 1 DB session for no-nodes early return, got {call_count[0]}"
+    )

--- a/tests/unit/test_health_db_session_b20.py
+++ b/tests/unit/test_health_db_session_b20.py
@@ -5,9 +5,7 @@ any Salt subprocess calls, so the connection pool slot is not held for the
 entire (potentially 30s+) Salt collection window.
 """
 import uuid
-from contextlib import contextmanager
-from unittest.mock import MagicMock, call, patch
-
+from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary
- Split `collect_fleet_health` into two short-lived DB sessions
- Session 1: loads online nodes (milliseconds), closes **before** any Salt calls
- Salt metric collection runs with no DB connection held (was holding the slot for 30s+ per batch)
- Session 2: persists snapshots after all Salt calls complete
- `node_by_minion` now stores plain dicts `{id, minion_id}` instead of ORM objects to avoid `DetachedInstanceError` after session 1 closes

## Test plan
- [x] Unit: `test_collect_fleet_health_closes_session_before_salt_calls` — session 1 `__exit__` fires before `collect_all_metrics` is invoked
- [x] Unit: `test_collect_fleet_health_uses_two_sessions` — exactly 2 `get_sync_db()` calls when nodes exist; `db.add` only on session 2
- [x] Unit: `test_collect_fleet_health_no_nodes_uses_one_session` — early return uses only 1 session

`cleanup_old_health_snapshots` is unchanged.

Closes #124

🤖 Generated with Claude Code