### PR TITLE
fix: convert node_health_snapshots and ansible_jobs to TimescaleDB hypertables

### DIFF
--- a/fleet_platform/db/migrations/versions/024_timescale_hypertables.py
+++ b/fleet_platform/db/migrations/versions/024_timescale_hypertables.py
@@ -1,0 +1,55 @@
+"""Convert node_health_snapshots and ansible_jobs to TimescaleDB hypertables
+
+Revision ID: 024
+Revises: 023
+Create Date: 2026-05-28
+"""
+from alembic import op
+
+revision = "024"
+down_revision = "023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── node_health_snapshots ─────────────────────────────────────────
+    # TimescaleDB requires all unique constraints to include the partition column.
+    # Drop the existing UUID-only PK and recreate as (id, collected_at).
+    op.execute("ALTER TABLE node_health_snapshots DROP CONSTRAINT node_health_snapshots_pkey")
+    op.execute(
+        "ALTER TABLE node_health_snapshots ADD PRIMARY KEY (id, collected_at)"
+    )
+    op.execute(
+        "SELECT create_hypertable('node_health_snapshots', by_range('collected_at', INTERVAL '1 day'))"
+    )
+    op.execute(
+        "SELECT add_compression_policy('node_health_snapshots', INTERVAL '7 days')"
+    )
+    op.execute(
+        "SELECT add_retention_policy('node_health_snapshots', INTERVAL '90 days')"
+    )
+
+    # ── ansible_jobs ─────────────────────────────────────────────────
+    op.execute("ALTER TABLE ansible_jobs DROP CONSTRAINT ansible_jobs_pkey")
+    op.execute(
+        "ALTER TABLE ansible_jobs ADD PRIMARY KEY (id, created_at)"
+    )
+    op.execute(
+        "SELECT create_hypertable('ansible_jobs', by_range('created_at', INTERVAL '1 day'))"
+    )
+    op.execute(
+        "SELECT add_compression_policy('ansible_jobs', INTERVAL '7 days')"
+    )
+    op.execute(
+        "SELECT add_retention_policy('ansible_jobs', INTERVAL '90 days')"
+    )
+
+
+def downgrade() -> None:
+    # Hypertable conversion is not reversible without data migration.
+    # Remove policies only; tables remain as hypertables.
+    op.execute("SELECT remove_retention_policy('ansible_jobs', if_exists => true)")
+    op.execute("SELECT remove_compression_policy('ansible_jobs', if_exists => true)")
+    op.execute("SELECT remove_retention_policy('node_health_snapshots', if_exists => true)")
+    op.execute("SELECT remove_compression_policy('node_health_snapshots', if_exists => true)")

--- a/fleet_platform/db/migrations/versions/024_timescale_hypertables.py
+++ b/fleet_platform/db/migrations/versions/024_timescale_hypertables.py
@@ -49,7 +49,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     # Hypertable conversion is not reversible without data migration.
     # Remove policies only; tables remain as hypertables.
-    op.execute("SELECT remove_retention_policy('ansible_jobs', if_exists => true)")
-    op.execute("SELECT remove_compression_policy('ansible_jobs', if_exists => true)")
-    op.execute("SELECT remove_retention_policy('node_health_snapshots', if_exists => true)")
-    op.execute("SELECT remove_compression_policy('node_health_snapshots', if_exists => true)")
+    op.execute("SELECT remove_retention_policy('ansible_jobs', true)")
+    op.execute("SELECT remove_compression_policy('ansible_jobs', true)")
+    op.execute("SELECT remove_retention_policy('node_health_snapshots', true)")
+    op.execute("SELECT remove_compression_policy('node_health_snapshots', true)")

--- a/tests/unit/test_timescale_hypertables_migration_024.py
+++ b/tests/unit/test_timescale_hypertables_migration_024.py
@@ -1,0 +1,97 @@
+"""Tests for migration 024: TimescaleDB hypertables conversion.
+
+Verifies that node_health_snapshots and ansible_jobs are properly
+converted to TimescaleDB hypertables with correct policies.
+"""
+
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).parent.parent.parent
+    / "fleet_platform/db/migrations/versions/024_timescale_hypertables.py"
+)
+
+
+def load_migration_source() -> str:
+    """Load the migration file source code."""
+    return MIGRATION_PATH.read_text()
+
+
+class TestMigrationMetadata:
+    """Test basic migration metadata."""
+
+    def test_migration_revision(self) -> None:
+        """Test migration revision is 024."""
+        migration = load_migration_source()
+        assert 'revision = "024"' in migration
+
+    def test_migration_down_revision(self) -> None:
+        """Test migration down_revision is 023."""
+        migration = load_migration_source()
+        assert 'down_revision = "023"' in migration
+
+
+class TestNodeHealthSnapshotsConversion:
+    """Test node_health_snapshots hypertable conversion."""
+
+    def test_hypertable_creation(self) -> None:
+        """Test create_hypertable call for node_health_snapshots."""
+        migration = load_migration_source()
+        assert "create_hypertable('node_health_snapshots'" in migration
+
+    def test_compression_policy(self) -> None:
+        """Test add_compression_policy for node_health_snapshots."""
+        migration = load_migration_source()
+        assert "add_compression_policy('node_health_snapshots'" in migration
+
+    def test_retention_policy(self) -> None:
+        """Test add_retention_policy for node_health_snapshots."""
+        migration = load_migration_source()
+        assert "add_retention_policy('node_health_snapshots'" in migration
+
+    def test_time_column(self) -> None:
+        """Test correct time column collected_at is used."""
+        migration = load_migration_source()
+        # Verify collected_at is used for node_health_snapshots hypertable creation
+        assert "'node_health_snapshots', by_range('collected_at'" in migration
+
+
+class TestAnsibleJobsConversion:
+    """Test ansible_jobs hypertable conversion."""
+
+    def test_hypertable_creation(self) -> None:
+        """Test create_hypertable call for ansible_jobs."""
+        migration = load_migration_source()
+        assert "create_hypertable('ansible_jobs'" in migration
+
+    def test_compression_policy(self) -> None:
+        """Test add_compression_policy for ansible_jobs."""
+        migration = load_migration_source()
+        assert "add_compression_policy('ansible_jobs'" in migration
+
+    def test_retention_policy(self) -> None:
+        """Test add_retention_policy for ansible_jobs."""
+        migration = load_migration_source()
+        assert "add_retention_policy('ansible_jobs'" in migration
+
+    def test_time_column(self) -> None:
+        """Test correct time column created_at is used."""
+        migration = load_migration_source()
+        # Verify created_at is used for ansible_jobs hypertable creation
+        assert "'ansible_jobs', by_range('created_at'" in migration
+
+
+class TestDowngradeLogic:
+    """Test migration downgrade logic."""
+
+    def test_remove_retention_policies(self) -> None:
+        """Test downgrade removes retention policies."""
+        migration = load_migration_source()
+        assert "remove_retention_policy" in migration
+        assert "ansible_jobs" in migration
+        assert "node_health_snapshots" in migration
+
+    def test_remove_compression_policies(self) -> None:
+        """Test downgrade removes compression policies."""
+        migration = load_migration_source()
+        assert "remove_compression_policy" in migration

--- a/tests/unit/test_timescale_hypertables_migration_024.py
+++ b/tests/unit/test_timescale_hypertables_migration_024.py
@@ -85,13 +85,13 @@ class TestDowngradeLogic:
     """Test migration downgrade logic."""
 
     def test_remove_retention_policies(self) -> None:
-        """Test downgrade removes retention policies."""
+        """Test downgrade removes retention policies for both tables."""
         migration = load_migration_source()
-        assert "remove_retention_policy" in migration
-        assert "ansible_jobs" in migration
-        assert "node_health_snapshots" in migration
+        assert "remove_retention_policy('ansible_jobs'" in migration
+        assert "remove_retention_policy('node_health_snapshots'" in migration
 
     def test_remove_compression_policies(self) -> None:
-        """Test downgrade removes compression policies."""
+        """Test downgrade removes compression policies for both tables."""
         migration = load_migration_source()
-        assert "remove_compression_policy" in migration
+        assert "remove_compression_policy('ansible_jobs'" in migration
+        assert "remove_compression_policy('node_health_snapshots'" in migration


### PR DESCRIPTION
## Summary
- Adds Alembic migration 024 converting `node_health_snapshots` and `ansible_jobs` to TimescaleDB hypertables
- Both tables get 1-day partitioning, 7-day compression, 90-day retention policies
- Primary keys updated to include the time-partition column (required by TimescaleDB)

## Test plan
- [ ] 12 unit tests verify migration SQL content: hypertable creation, compression, retention, time columns, downgrade policies
- [ ] Full unit suite passes (542 tests)
- [ ] Ruff lint clean

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)