### PR TITLE
feat: show last playbook run duration in PlaybookRunModal (#165)

### DIFF
--- a/fleet_platform/api/routes/ansible.py
+++ b/fleet_platform/api/routes/ansible.py
@@ -1080,6 +1080,44 @@ async def update_playbook_file(
     return {"path": path, "size": target.stat().st_size, "saved": True}
 
 
+@router.get("/playbooks/{playbook_name:path}/stats")
+async def playbook_stats(
+    playbook_name: str,
+    db: AsyncSession = Depends(get_db),
+    _: dict = Depends(require_role("operator", "admin")),
+) -> dict:
+    """Return duration statistics for the last 5 completed runs of a playbook."""
+    rows = await db.execute(
+        select(AnsibleJob)
+        .where(
+            AnsibleJob.playbook == playbook_name,
+            AnsibleJob.status == "completed",
+            AnsibleJob.started_at.is_not(None),
+            AnsibleJob.completed_at.is_not(None),
+        )
+        .order_by(AnsibleJob.completed_at.desc())
+        .limit(5)
+    )
+    jobs = rows.scalars().all()
+
+    durations = []
+    for j in jobs:
+        if j.started_at and j.completed_at:
+            secs = (j.completed_at - j.started_at).total_seconds()
+            if secs > 0:
+                durations.append(int(secs))
+
+    if not durations:
+        return {"playbook": playbook_name, "run_count": 0, "last_duration_seconds": None, "avg_duration_seconds": None}
+
+    return {
+        "playbook": playbook_name,
+        "run_count": len(durations),
+        "last_duration_seconds": durations[0],
+        "avg_duration_seconds": int(sum(durations) / len(durations)),
+    }
+
+
 @router.get("/tasks/{task_id}")
 async def get_task_status(
     task_id: str,

--- a/frontend/src/api/playbooks.ts
+++ b/frontend/src/api/playbooks.ts
@@ -32,9 +32,18 @@ export interface AnsibleJob {
   created_at: string
 }
 
+export interface PlaybookStats {
+  playbook: string
+  run_count: number
+  last_duration_seconds: number | null
+  avg_duration_seconds: number | null
+}
+
 export const playbooksApi = {
   list: () => api.get<PlaybookEntry[]>('/api/v1/ansible/playbooks'),
   run: (playbook: string, target_type: string, target_id: string, extravars: Record<string, unknown>, sshUsername?: string, sshPassword?: string) =>
     api.post<PlaybookRunResponse>('/api/v1/ansible/playbooks/run', { playbook, target_type, target_id, extravars, ssh_username: sshUsername || undefined, ssh_password: sshPassword || undefined }),
   getJob: (jobId: string) => api.get<AnsibleJob>(`/api/v1/ansible/jobs/${jobId}`),
+  getStats: (filename: string) =>
+    api.get<PlaybookStats>(`/api/v1/ansible/playbooks/${encodeURIComponent(filename)}/stats`),
 }

--- a/frontend/src/pages/PlaybookRunModal.tsx
+++ b/frontend/src/pages/PlaybookRunModal.tsx
@@ -24,6 +24,12 @@ const STATUS_STYLE: Record<string, { label: string; colour: string }> = {
   failed:    { label: 'Failed',   colour: 'text-red-700' },
 }
 
+function fmtDuration(secs: number): string {
+  const m = Math.floor(secs / 60)
+  const s = secs % 60
+  return m > 0 ? `${m}m ${s}s` : `${s}s`
+}
+
 export function PlaybookRunModal({ playbook, onClose }: Props) {
   const [targetType, setTargetType] = useState<'node' | 'group'>('node')
   const [targetId, setTargetId] = useState('')
@@ -64,6 +70,12 @@ export function PlaybookRunModal({ playbook, onClose }: Props) {
     queryKey: ['groups-for-playbook'],
     queryFn: () => groupsApi.list({ per_page: 200 }),
     enabled: targetType === 'group',
+    staleTime: 60_000,
+  })
+
+  const { data: statsData } = useQuery({
+    queryKey: ['playbook-stats', playbook.filename],
+    queryFn: () => playbooksApi.getStats(playbook.filename),
     staleTime: 60_000,
   })
 
@@ -110,7 +122,12 @@ export function PlaybookRunModal({ playbook, onClose }: Props) {
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
           <div>
             <h2 className="text-lg font-bold text-gray-900">Run Playbook</h2>
-            <p className="text-sm text-gray-500">{playbook.name}</p>
+            <div className="flex items-baseline gap-2">
+              <p className="text-sm text-gray-500">{playbook.name}</p>
+              {statsData && statsData.run_count > 0 && statsData.last_duration_seconds !== null && (
+                <p className="text-sm text-gray-400">Last run: {fmtDuration(statsData.last_duration_seconds)}</p>
+              )}
+            </div>
           </div>
           <button onClick={onClose} className="flex items-center justify-center w-8 h-8 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors text-lg">×</button>
         </div>

--- a/tests/unit/test_playbook_duration_b33.py
+++ b/tests/unit/test_playbook_duration_b33.py
@@ -1,0 +1,32 @@
+"""Tests for #165: playbook duration stats endpoint."""
+from pathlib import Path
+
+ANSIBLE_ROUTE = (Path(__file__).parent.parent.parent / "fleet_platform/api/routes/ansible.py").read_text()
+
+
+def test_playbook_stats_endpoint_exists():
+    assert "playbook_stats" in ANSIBLE_ROUTE
+
+def test_playbook_stats_endpoint_path():
+    assert "/playbooks/{playbook_name" in ANSIBLE_ROUTE
+
+def test_playbook_stats_returns_last_duration():
+    assert "last_duration_seconds" in ANSIBLE_ROUTE
+
+def test_playbook_stats_returns_avg_duration():
+    assert "avg_duration_seconds" in ANSIBLE_ROUTE
+
+def test_playbook_stats_limits_to_5_runs():
+    assert ".limit(5)" in ANSIBLE_ROUTE
+
+def test_playbook_stats_only_completed_jobs():
+    assert '"completed"' in ANSIBLE_ROUTE
+
+def test_fmtduration_in_frontend():
+    modal = (Path(__file__).parent.parent.parent / "frontend/src/pages/PlaybookRunModal.tsx").read_text()
+    assert "fmtDuration" in modal or "last_duration_seconds" in modal
+
+def test_playbook_stats_api_in_frontend():
+    api = (Path(__file__).parent.parent.parent / "frontend/src/api/playbooks.ts").read_text()
+    assert "getStats" in api
+    assert "PlaybookStats" in api


### PR DESCRIPTION
## Summary

- New endpoint `GET /api/v1/ansible/playbooks/{playbook_name}/stats` returning duration stats from last 5 completed runs
- `PlaybookRunModal` fetches stats on open and shows **"Last run: Xm Ys"** hint below the playbook name
- No schema migration needed — uses existing `started_at`/`completed_at` fields on `AnsibleJob`

## Test plan
- [x] `pytest tests/unit/test_playbook_duration_b33.py` — 8/8 pass
- [x] `ruff check` — clean
- [x] `npm run build` — 0 type errors

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)