### PR TITLE
feat: keyboard shortcuts — Escape, ?, Ctrl+K (#163)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.0.0",
+  "version": "0.1.143",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.0.0",
+      "version": "0.1.143",
       "license": "UNLICENSED",
       "dependencies": {
         "@novnc/novnc": "^1.7.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthGuard } from './components/AuthGuard'
@@ -30,6 +30,8 @@ import { useSaltKeysStore } from './stores/saltKeysStore'
 import { useToastStore } from './stores/toastStore'
 import { useAuthStore } from './stores/authStore'
 import LLMAssistant from './components/LLMAssistant'
+import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
+import { KeyboardShortcutsOverlay } from './components/KeyboardShortcutsOverlay'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -92,10 +94,29 @@ function NotFoundPage() {
 }
 
 export default function App() {
+  const [shortcutsOpen, setShortcutsOpen] = useState(false)
+
+  useKeyboardShortcuts({
+    '?': () => setShortcutsOpen((v) => !v),
+    'ctrl+k': () => {
+      const input = document.querySelector<HTMLInputElement>(
+        'input[type="search"], input[placeholder*="search" i], input[placeholder*="filter" i]'
+      )
+      input?.focus()
+    },
+    '/': () => {
+      const input = document.querySelector<HTMLInputElement>(
+        'input[type="search"], input[placeholder*="search" i], input[placeholder*="filter" i]'
+      )
+      input?.focus()
+    },
+  })
+
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <SaltKeyWatcher />
+        <KeyboardShortcutsOverlay open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route path="/auth/callback" element={<OidcCallbackPage />} />

--- a/frontend/src/components/KeyboardShortcutsOverlay.tsx
+++ b/frontend/src/components/KeyboardShortcutsOverlay.tsx
@@ -1,0 +1,50 @@
+import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+export function KeyboardShortcutsOverlay({ open, onClose }: Props) {
+  useKeyboardShortcuts({ Escape: onClose }, open)
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="bg-[#111827] border border-gray-700 rounded-xl p-6 w-80 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-white font-semibold text-lg mb-4">Keyboard Shortcuts</h2>
+        <table className="w-full text-sm">
+          <tbody className="space-y-2">
+            {[
+              ['?', 'Show this overlay'],
+              ['Escape', 'Close modal / overlay'],
+              ['Ctrl+K or /', 'Focus search / filter'],
+            ].map(([key, desc]) => (
+              <tr key={key} className="border-b border-gray-800">
+                <td className="py-2 pr-4">
+                  <kbd className="bg-gray-800 text-gray-200 px-2 py-0.5 rounded text-xs font-mono">
+                    {key}
+                  </kbd>
+                </td>
+                <td className="py-2 text-gray-400">{desc}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <button
+          onClick={onClose}
+          className="mt-4 text-xs text-gray-500 hover:text-gray-300"
+        >
+          Press Escape or ? to close
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+
+export type ShortcutMap = Record<string, () => void>
+
+export function useKeyboardShortcuts(shortcuts: ShortcutMap, enabled = true): void {
+  useEffect(() => {
+    if (!enabled) return
+
+    function handler(e: KeyboardEvent) {
+      // Don't fire when typing in inputs/textareas
+      const tag = (e.target as HTMLElement).tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+        // Allow Escape even in inputs
+        if (e.key !== 'Escape') return
+      }
+
+      const key = [
+        e.ctrlKey && 'ctrl',
+        e.metaKey && 'meta',
+        e.shiftKey && 'shift',
+        e.key,
+      ]
+        .filter(Boolean)
+        .join('+')
+
+      if (shortcuts[key]) {
+        shortcuts[key]()
+        e.preventDefault()
+      }
+    }
+
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [shortcuts, enabled])
+}

--- a/tests/unit/test_keyboard_shortcuts_b34.py
+++ b/tests/unit/test_keyboard_shortcuts_b34.py
@@ -1,0 +1,46 @@
+"""Tests for #163: keyboard shortcuts."""
+from pathlib import Path
+
+HOOK = (Path(__file__).parent.parent.parent / "frontend/src/hooks/useKeyboardShortcuts.ts").read_text()
+OVERLAY = (Path(__file__).parent.parent.parent / "frontend/src/components/KeyboardShortcutsOverlay.tsx").read_text()
+APP = (Path(__file__).parent.parent.parent / "frontend/src/App.tsx").read_text()
+
+
+def test_hook_file_exists():
+    assert "useKeyboardShortcuts" in HOOK
+
+
+def test_hook_ignores_input_elements():
+    assert "INPUT" in HOOK or "input" in HOOK.lower()
+
+
+def test_hook_allows_escape_in_inputs():
+    assert "Escape" in HOOK
+
+
+def test_overlay_lists_escape_shortcut():
+    assert "Escape" in OVERLAY
+
+
+def test_overlay_lists_search_shortcut():
+    assert "Ctrl+K" in OVERLAY or "ctrl+k" in OVERLAY.lower()
+
+
+def test_overlay_lists_question_mark():
+    assert '"?"' in OVERLAY or "'?'" in OVERLAY
+
+
+def test_app_registers_question_mark_shortcut():
+    assert '"?"' in APP or "'?'" in APP
+
+
+def test_app_renders_overlay():
+    assert "KeyboardShortcutsOverlay" in APP
+
+
+def test_app_registers_ctrl_k():
+    assert "ctrl+k" in APP.lower() or "ctrl+K" in APP
+
+
+def test_hook_prevents_default():
+    assert "preventDefault" in HOOK


### PR DESCRIPTION
## Summary

- `useKeyboardShortcuts` hook — generic, composable, suppresses shortcuts while typing in inputs (except Escape)
- `KeyboardShortcutsOverlay` — dark-themed modal listing all shortcuts, dismissible with `?` or Escape
- Registered at App root: `?` toggles overlay, `Ctrl+K`/`/` focus nearest search input, `Escape` closes overlays

## Shortcuts added
| Key | Action |
|-----|--------|
| `?` | Show/hide keyboard shortcuts overlay |
| `Escape` | Close open modal or overlay |
| `Ctrl+K` / `/` | Focus search/filter input on current page |

## Test plan
- [x] `pytest tests/unit/test_keyboard_shortcuts_b34.py` — 10/10 pass
- [x] `npm run build` — 0 type errors

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)