### PR TITLE
feat: SBOM delta — new/removed packages since last scan (#167)

### DIFF
--- a/fleet_platform/api/routes/sbom.py
+++ b/fleet_platform/api/routes/sbom.py
@@ -11,6 +11,8 @@ from fleet_platform.models.sbom import SBOMComponent, SBOMScan
 from fleet_platform.schemas.common import PaginatedResponse
 from fleet_platform.schemas.sbom import (
     SBOMComponentResponse,
+    SBOMDeltaResponse,
+    SBOMPackage,
     SBOMScanResponse,
     SBOMSearchResult,
 )
@@ -193,4 +195,71 @@ async def list_scan_components(
         total=total,
         page=page,
         per_page=per_page,
+    )
+
+
+@router.get("/delta/{node_id}", response_model=SBOMDeltaResponse)
+async def sbom_delta(
+    node_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _: dict = Depends(get_current_user),
+) -> SBOMDeltaResponse:
+    """Return packages added/removed between the two most recent SBOM scans for a node."""
+    # Get the two most recent scans for this node
+    scans_result = await db.execute(
+        select(SBOMScan)
+        .where(SBOMScan.node_id == node_id)
+        .order_by(SBOMScan.scanned_at.desc())
+        .limit(2)
+    )
+    scans = scans_result.scalars().all()
+
+    if len(scans) < 2:
+        return SBOMDeltaResponse(
+            node_id=str(node_id),
+            has_delta=False,
+            new_packages=[],
+            removed_packages=[],
+            new_count=0,
+            removed_count=0,
+            message="Need at least 2 scans to compute delta",
+        )
+
+    latest, previous = scans[0], scans[1]
+
+    # Get package identifiers from each scan (use purl if available, else name+version)
+    async def get_package_set(scan_id: uuid.UUID) -> dict[str, dict]:
+        result = await db.execute(
+            select(SBOMComponent.name, SBOMComponent.version, SBOMComponent.purl).where(
+                SBOMComponent.scan_id == scan_id
+            )
+        )
+        packages = {}
+        for name, version, purl in result.all():
+            key = purl or f"{name}@{version or 'unknown'}"
+            packages[key] = {"name": name, "version": version or "", "purl": purl or ""}
+        return packages
+
+    latest_pkgs = await get_package_set(latest.id)
+    prev_pkgs = await get_package_set(previous.id)
+
+    latest_keys = set(latest_pkgs.keys())
+    prev_keys = set(prev_pkgs.keys())
+
+    new_keys = latest_keys - prev_keys
+    removed_keys = prev_keys - latest_keys
+
+    return SBOMDeltaResponse(
+        node_id=str(node_id),
+        has_delta=True,
+        latest_scan_at=latest.scanned_at,
+        previous_scan_at=previous.scanned_at,
+        new_packages=[
+            SBOMPackage(**latest_pkgs[k]) for k in sorted(new_keys)
+        ],
+        removed_packages=[
+            SBOMPackage(**prev_pkgs[k]) for k in sorted(removed_keys)
+        ],
+        new_count=len(new_keys),
+        removed_count=len(removed_keys),
     )

--- a/fleet_platform/schemas/sbom.py
+++ b/fleet_platform/schemas/sbom.py
@@ -38,3 +38,21 @@ class SBOMSearchResult(BaseModel):
     node_id: uuid.UUID
     scan_id: uuid.UUID
     scanned_at: datetime
+
+
+class SBOMPackage(BaseModel):
+    name: str
+    version: str
+    purl: str
+
+
+class SBOMDeltaResponse(BaseModel):
+    node_id: str
+    has_delta: bool
+    new_packages: list[SBOMPackage]
+    removed_packages: list[SBOMPackage]
+    new_count: int
+    removed_count: int
+    latest_scan_at: datetime | None = None
+    previous_scan_at: datetime | None = None
+    message: str | None = None

--- a/frontend/src/api/sbom.ts
+++ b/frontend/src/api/sbom.ts
@@ -1,5 +1,5 @@
 import { api } from './client'
-import type { Paginated, SBOMComponent, SBOMScan, SBOMSearchResult } from '../types'
+import type { Paginated, SBOMComponent, SBOMDelta, SBOMScan, SBOMSearchResult } from '../types'
 
 export const sbomApi = {
   latestScan: (nodeId: string) => api.get<SBOMScan>(`/api/v1/sbom/${nodeId}/latest`),
@@ -21,4 +21,6 @@ export const sbomApi = {
     api.get<SBOMSearchResult[]>(`/api/v1/sbom/search?q=${encodeURIComponent(q)}`),
   browse: () =>
     api.get<SBOMSearchResult[]>('/api/v1/sbom/browse'),
+  getDelta: (nodeId: string) =>
+    api.get<SBOMDelta>(`/api/v1/sbom/delta/${nodeId}`),
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -133,6 +133,24 @@ export interface SBOMSearchResult {
   scanned_at: string
 }
 
+export interface SBOMPackage {
+  name: string
+  version: string
+  purl: string
+}
+
+export interface SBOMDelta {
+  node_id: string
+  has_delta: boolean
+  new_count: number
+  removed_count: number
+  new_packages: SBOMPackage[]
+  removed_packages: SBOMPackage[]
+  latest_scan_at?: string
+  previous_scan_at?: string
+  message?: string
+}
+
 export interface Group {
   id: string
   name: string

--- a/tests/unit/test_sbom_delta_b41.py
+++ b/tests/unit/test_sbom_delta_b41.py
@@ -1,0 +1,40 @@
+"""Tests for #167: SBOM delta endpoint."""
+from pathlib import Path
+
+SBOM_ROUTE = (Path(__file__).parent.parent.parent / "fleet_platform/api/routes/sbom.py").read_text()
+
+
+def test_sbom_delta_endpoint_exists():
+    assert "sbom_delta" in SBOM_ROUTE or "delta" in SBOM_ROUTE
+
+
+def test_sbom_delta_endpoint_path():
+    assert "/delta/" in SBOM_ROUTE or "delta/{node_id}" in SBOM_ROUTE
+
+
+def test_sbom_delta_returns_new_packages():
+    assert "new_packages" in SBOM_ROUTE
+
+
+def test_sbom_delta_returns_removed_packages():
+    assert "removed_packages" in SBOM_ROUTE
+
+
+def test_sbom_delta_handles_insufficient_scans():
+    assert "has_delta" in SBOM_ROUTE
+
+
+def test_sbom_delta_limits_to_2_scans():
+    assert ".limit(2)" in SBOM_ROUTE
+
+
+def test_sbom_delta_uses_purl_key():
+    assert "purl" in SBOM_ROUTE
+
+
+def test_sbom_delta_in_frontend():
+    # Check the frontend sbom API file has getDelta
+    api_files = list((Path(__file__).parent.parent.parent / "frontend/src/api").glob("sbom*.ts"))
+    assert api_files, "No sbom API file found in frontend/src/api/"
+    content = api_files[0].read_text()
+    assert "getDelta" in content or "delta" in content.lower()


### PR DESCRIPTION
## Summary

- `GET /api/v1/sbom/delta/{node_id}` — compares the two most recent SBOM scans, returns new and removed packages
- Uses `purl` as canonical package key, falls back to `name@version`
- Returns `has_delta: false` gracefully when fewer than 2 scans exist
- `SBOMDeltaResponse` Pydantic schema + `SBOMDelta` TypeScript interface
- `getDelta()` method added to `sbomApi` frontend client

## Test plan
- [x] `pytest tests/unit/test_sbom_delta_b41.py` — 8/8 pass
- [x] `ruff check fleet_platform/api/routes/sbom.py` — clean
- [x] `npm run build` — 0 type errors

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)