### PR TITLE
feat: auto-resolve playbook SSH credentials per host (closes #279)

### DIFF
--- a/fleet_platform/services/credential_resolver.py
+++ b/fleet_platform/services/credential_resolver.py
@@ -115,6 +115,77 @@ async def resolve_node_credentials(node: Node, db: AsyncSession) -> dict:
     }
 
 
+def _decrypt_or_blank(label: str, ident, field: str, ciphertext: str | None) -> str:
+    if not ciphertext:
+        return ""
+    try:
+        return decrypt_secret(ciphertext)
+    except Exception as exc:
+        logger.warning("Fernet decryption failed for %s %s field %s: %s", label, ident, field, exc)
+        return ""
+
+
+def resolve_node_credentials_sync(node: Node, db) -> dict:
+    """Synchronous twin of :func:`resolve_node_credentials` for the Celery worker.
+
+    The playbook worker runs on a sync SQLAlchemy ``Session`` (``get_sync_db``),
+    so it cannot await the async resolver. This mirrors the same
+    node → primary-group → global priority chain and returns the identical
+    dict shape, including ``credential_source`` (#279).
+    """
+    # 1. Node-level override
+    if node.ssh_username:
+        return {
+            "ssh_user": node.ssh_username,
+            "ssh_password": _decrypt_or_blank("node", node.id, "ssh_password", node.ssh_password_enc),
+            "ssh_key": _decrypt_or_blank("node", node.id, "ssh_key", node.ssh_key_enc),
+            "auth_mode": node.ssh_auth_mode or "password",
+            "credential_source": "node",
+        }
+
+    # 2. Primary group (alphabetically-first group that has credentials)
+    group = db.execute(
+        select(Group)
+        .join(GroupMember, GroupMember.group_id == Group.id)
+        .where(GroupMember.node_id == node.id)
+        .where(Group.ssh_username.isnot(None))
+        .order_by(Group.name.asc())
+        .limit(1)
+    ).scalar_one_or_none()
+    if group and group.ssh_username:
+        return {
+            "ssh_user": group.ssh_username,
+            "ssh_password": _decrypt_or_blank("group", group.name, "ssh_password", group.ssh_password_enc),
+            "ssh_key": _decrypt_or_blank("group", group.name, "ssh_key", group.ssh_key_enc),
+            "auth_mode": group.ssh_auth_mode or "password",
+            "credential_source": f"group:{group.name}",
+        }
+
+    # 3. Global fallback from platform settings
+    return {
+        "ssh_user": _get_global_setting_sync(db, SSH_USERNAME) or "admin",
+        "ssh_password": _get_global_setting_sync(db, SSH_PASSWORD, encrypted=True),
+        "ssh_key": "",
+        "auth_mode": "password",
+        "credential_source": "global",
+    }
+
+
+def _get_global_setting_sync(db, key: str, encrypted: bool = False) -> str:
+    row = db.execute(
+        select(PlatformSetting).where(PlatformSetting.key == key)
+    ).scalar_one_or_none()
+    if not row or not row.value:
+        return ""
+    if encrypted and row.is_encrypted:
+        try:
+            return _fernet().decrypt(row.value.encode()).decode()
+        except Exception as exc:
+            logger.warning("Fernet decryption failed for global platform setting %s: %s", key, exc)
+            return ""
+    return row.value or ""
+
+
 async def _get_global_setting(db: AsyncSession, key: str, encrypted: bool = False) -> str:
     result = await db.execute(
         select(PlatformSetting).where(PlatformSetting.key == key)

--- a/fleet_platform/workers/playbook_tasks.py
+++ b/fleet_platform/workers/playbook_tasks.py
@@ -16,7 +16,7 @@ from sqlalchemy import select
 from fleet_platform.db.session import get_sync_db
 from fleet_platform.models.ansible_job import AnsibleJob
 from fleet_platform.models.node import Node
-from fleet_platform.workers.ansible_tasks import _get_bootstrap_settings
+from fleet_platform.services.credential_resolver import resolve_node_credentials_sync
 from fleet_platform.workers.celery_app import celery_app
 
 _DEFAULT_PLAYBOOKS_DIR = Path(__file__).parent.parent.parent / "playbooks"
@@ -73,14 +73,44 @@ def _resolve_playbook_path(playbook_filename: str, db) -> tuple[Path, Path]:
     return _DEFAULT_PLAYBOOKS_DIR / playbook_filename, _DEFAULT_PLAYBOOKS_DIR
 
 
-def _write_static_inventory(tmpdir: str, hosts: list[tuple[str, str, str]]) -> str:
+_SOURCE_LABELS = {"node": "node override", "global": "global default", "manual": "manual override"}
+
+
+def _source_label(source: str) -> str:
+    # group sources keep their "group:<name>" form; others get a friendly label
+    return _SOURCE_LABELS.get(source, source)
+
+
+def _write_static_inventory(tmpdir: str, hosts: list[dict]) -> str:
+    """Write a per-host inventory with each host's resolved SSH credentials.
+
+    Credentials differ per host (node override vs group vs global), so they go
+    inline per host rather than via a single global env var. Private keys are
+    written to 0600 files in *tmpdir* and referenced, never inlined (#279).
+    """
     lines = ["[targets]"]
-    for hostname, ip, user in hosts:
-        lines.append(f"{hostname} ansible_host={ip} ansible_user={user}")
+    for h in hosts:
+        parts = [h["hostname"], f"ansible_host={h['ip']}", f"ansible_user={h['ssh_user']}"]
+        if h.get("auth_mode") == "key" and h.get("ssh_key"):
+            key_path = Path(tmpdir) / f"{_safe_label(h['hostname'])}.key"
+            key_path.write_text(h["ssh_key"] if h["ssh_key"].endswith("\n") else h["ssh_key"] + "\n")
+            key_path.chmod(0o600)
+            parts.append(f"ansible_ssh_private_key_file={key_path}")
+        elif h.get("ssh_password"):
+            parts.append(f"ansible_ssh_pass={h['ssh_password']}")
+        lines.append(" ".join(parts))
     inv_path = Path(tmpdir) / "inventory.ini"
     inv_path.write_text("\n".join(lines))
-    inv_path.chmod(0o600)  # not world-readable — contains IP addresses
+    inv_path.chmod(0o600)  # holds SSH passwords + IPs — never world/group readable
     return str(inv_path)
+
+
+def _credential_source_banner(hosts: list[dict]) -> str:
+    """Human-readable summary of where each host's credentials came from (#279)."""
+    lines = ["Credentials resolved automatically (node → group → global):"]
+    for h in hosts:
+        lines.append(f"  {h['hostname']} ({h['ip']}) ← {_source_label(h['credential_source'])}")
+    return "\n".join(lines)
 
 
 def _write_var_file(path: Path, vars_dict: dict) -> None:
@@ -88,14 +118,37 @@ def _write_var_file(path: Path, vars_dict: dict) -> None:
     path.write_text(_yaml.dump(vars_dict, default_flow_style=False, allow_unicode=True))
 
 
-def _resolve_hosts(db, job: AnsibleJob, ssh_user: str) -> list[tuple[str, str, str]] | None:
+def _host_entry(node: Node, db, override: dict | None) -> dict:
+    """Build a host inventory entry, resolving credentials per node (#279).
+
+    *override* (an explicit ssh_user/ssh_password supplied via the API) wins
+    over the resolver and is reported as source ``manual``.
+    """
+    if override and override.get("ssh_user"):
+        creds = {
+            "ssh_user": override["ssh_user"],
+            "ssh_password": override.get("ssh_password") or "",
+            "ssh_key": "",
+            "auth_mode": "password",
+            "credential_source": "manual",
+        }
+    else:
+        creds = resolve_node_credentials_sync(node, db)
+    return {
+        "hostname": node.hostname or node.minion_id,
+        "ip": node.ip_address,
+        **creds,
+    }
+
+
+def _resolve_hosts(db, job: AnsibleJob, override: dict | None = None) -> list[dict] | None:
     if job.target_type == "node":
         node = db.execute(
             select(Node).where(Node.id == _uuid.UUID(job.target_id))
         ).scalar_one_or_none()
         if not node or not node.ip_address:
             return None
-        return [(node.hostname or node.minion_id, node.ip_address, ssh_user)]
+        return [_host_entry(node, db, override)]
 
     if job.target_type == "group":
         from fleet_platform.models.group import GroupMember
@@ -108,7 +161,7 @@ def _resolve_hosts(db, job: AnsibleJob, ssh_user: str) -> list[tuple[str, str, s
         nodes = db.execute(
             select(Node).where(Node.id.in_(node_ids), Node.ip_address.isnot(None))
         ).scalars().all()
-        return [(n.hostname or n.minion_id, n.ip_address, ssh_user) for n in nodes]
+        return [_host_entry(n, db, override) for n in nodes]
 
     return None
 
@@ -148,16 +201,16 @@ def run_playbook(self, job_id: str, ssh_username: str | None = None, ssh_passwor
             job.status = "running"
             job.started_at = datetime.now(UTC)
             db.commit()
-            _, _settings_ssh_user, _settings_ssh_password, _ = _get_bootstrap_settings(db)
-            ssh_user = ssh_username or _settings_ssh_user
-            ssh_password = _settings_ssh_password if ssh_password is None else ssh_password
+            # Explicit per-call override (optional, e.g. via API). When absent,
+            # credentials are auto-resolved per host (node → group → global).
+            override = {"ssh_user": ssh_username, "ssh_password": ssh_password} if ssh_username else None
 
             # Resolve playbook path across all configured sources (not just builtin)
             playbook_path, playbooks_dir = _resolve_playbook_path(job.playbook, db)
 
         with get_sync_db() as db:
             job = db.execute(select(AnsibleJob).where(AnsibleJob.id == job_uuid)).scalar_one()
-            hosts = _resolve_hosts(db, job, ssh_user)
+            hosts = _resolve_hosts(db, job, override)
 
         if not hosts:
             with get_sync_db() as db:
@@ -168,11 +221,20 @@ def run_playbook(self, job_id: str, ssh_username: str | None = None, ssh_passwor
                 db.commit()
             return {"status": "error", "reason": "no_hosts"}
 
+        # Tell the operator which credential source each host used (#279)
+        banner = _credential_source_banner(hosts)
+        stdout_lines.append(banner)
+        stdout_lines.append("")
+        with get_sync_db() as db:
+            job = db.execute(select(AnsibleJob).where(AnsibleJob.id == job_uuid)).scalar_one()
+            job.stdout = "\n".join(stdout_lines)
+            db.commit()
+
         with get_sync_db() as db:
             job = db.execute(select(AnsibleJob).where(AnsibleJob.id == job_uuid)).scalar_one()
             if job.extravars:
                 if job.target_type == "node" and hosts:
-                    hostname = _safe_label(hosts[0][0])
+                    hostname = _safe_label(hosts[0]["hostname"])
                     vf = playbooks_dir / "host_vars" / f"{hostname}.yml"
                     _write_var_file(vf, job.extravars)
                 elif job.target_type == "group":
@@ -191,8 +253,8 @@ def run_playbook(self, job_id: str, ssh_username: str | None = None, ssh_passwor
                 inventory=inv_path,
                 extravars=job.extravars or {},
                 envvars={
-                    "ANSIBLE_USER": ssh_user,
-                    "ANSIBLE_PASSWORD": ssh_password,
+                    # SSH credentials are set per host in the inventory (#279),
+                    # resolved node → group → global — not via a single global env.
                     "ANSIBLE_COLLECTIONS_PATH": str(playbooks_dir / "collections" / "installed"),
                     # Reduce SSH timeout so stalled tasks surface faster
                     "ANSIBLE_TIMEOUT": "30",

--- a/frontend/src/pages/PlaybookRunModal.tsx
+++ b/frontend/src/pages/PlaybookRunModal.tsx
@@ -4,7 +4,6 @@ import { playbooksApi } from '../api/playbooks'
 import type { PlaybookEntry } from '../api/playbooks'
 import { fleetApi } from '../api/fleet'
 import { groupsApi } from '../api/groups'
-import { ansibleApi } from '../api/ansible'
 import { useToastStore } from '../stores/toastStore'
 
 const SYSTEM_VARS = new Set([
@@ -34,9 +33,6 @@ export function PlaybookRunModal({ playbook, onClose }: Props) {
   const [targetType, setTargetType] = useState<'node' | 'group'>('node')
   const [targetId, setTargetId] = useState('')
   const [jobId, setJobId] = useState<string | null>(null)
-  const [sshUsername, setSshUsername] = useState('')
-  const [sshPassword, setSshPassword] = useState('')
-  const [showSshPassword, setShowSshPassword] = useState(false)
   const [vars, setVars] = useState<Record<string, string>>(
     Object.fromEntries(
       Object.entries(playbook.default_vars).map(([k, v]) => [k, String(v ?? '')])
@@ -44,20 +40,6 @@ export function PlaybookRunModal({ playbook, onClose }: Props) {
   )
   const toast = useToastStore((s) => s.add)
   const qc = useQueryClient()
-
-  // Load SSH credential defaults from platform settings
-  const { data: settingsData } = useQuery({
-    queryKey: ['platform-settings'],
-    queryFn: () => ansibleApi.getSettings(),
-    staleTime: 60_000,
-  })
-
-  useEffect(() => {
-    if (settingsData) {
-      if (!sshUsername) setSshUsername(settingsData.ssh_bootstrap_username || '')
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [settingsData])
 
   const { data: nodes } = useQuery({
     queryKey: ['nodes-for-playbook'],
@@ -88,7 +70,7 @@ export function PlaybookRunModal({ playbook, onClose }: Props) {
         else if (v !== '' && !isNaN(Number(v))) extravars[k] = Number(v)
         else extravars[k] = v
       }
-      return playbooksApi.run(playbook.filename, targetType, targetId, extravars, sshUsername || undefined, sshPassword || undefined)
+      return playbooksApi.run(playbook.filename, targetType, targetId, extravars)
     },
     onSuccess: (data) => { setJobId(data.job_id); toast('Playbook queued') },
     onError: (e: Error) => toast(e.message, 'error'),
@@ -205,37 +187,16 @@ export function PlaybookRunModal({ playbook, onClose }: Props) {
                 </div>
               </div>
             )}
-            {/* SSH Credentials */}
-            <div className="border-t border-gray-100 pt-4 space-y-3">
-              <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">SSH Credentials</p>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Username</label>
-                  <input
-                    value={sshUsername}
-                    onChange={(e) => setSshUsername(e.target.value)}
-                    placeholder="admin"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm text-gray-900 focus:outline-none focus:border-brand-600"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
-                  <div className="relative">
-                    <input
-                      type={showSshPassword ? 'text' : 'password'}
-                      value={sshPassword}
-                      onChange={(e) => setSshPassword(e.target.value)}
-                      placeholder="••••••••"
-                      className="w-full px-3 py-2 pr-9 border border-gray-300 rounded-lg text-sm text-gray-900 focus:outline-none focus:border-brand-600"
-                    />
-                    <button type="button" onClick={() => setShowSshPassword(!showSshPassword)}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
-                      {showSshPassword ? '🙈' : '👁'}
-                    </button>
-                  </div>
-                </div>
+            {/* SSH Credentials — resolved automatically, no prompt */}
+            <div className="border-t border-gray-100 pt-4">
+              <div className="flex items-start gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2.5">
+                <span className="text-base leading-none mt-0.5" aria-hidden>🔑</span>
+                <p className="text-sm text-gray-600">
+                  SSH credentials are resolved automatically for each host
+                  <span className="text-gray-500"> (node&nbsp;→&nbsp;group&nbsp;→&nbsp;global settings)</span>.
+                  The run output shows which source was used per host.
+                </p>
               </div>
-              <p className="text-xs text-gray-400">Overrides global Settings credentials for this run only.</p>
             </div>
           </div>
         ) : (

--- a/tests/unit/test_credential_resolver_sync.py
+++ b/tests/unit/test_credential_resolver_sync.py
@@ -1,0 +1,89 @@
+# tests/unit/test_credential_resolver_sync.py
+"""Unit tests for the sync credential resolver used by the playbook worker (#279)."""
+import uuid
+from unittest.mock import MagicMock
+
+from fleet_platform.services.platform_settings_svc import _fernet, encrypt_secret
+
+
+def _sync_db(*scalar_returns):
+    """Build a MagicMock sync Session whose execute() returns results in order."""
+    db = MagicMock()
+    side_effects = []
+    for val in scalar_returns:
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = val
+        side_effects.append(result)
+    if len(side_effects) == 1:
+        db.execute.return_value = side_effects[0]
+    else:
+        db.execute.side_effect = side_effects
+    return db
+
+
+def _node(ssh_username=None, ssh_password_enc=None, ssh_key_enc=None, ssh_auth_mode=None):
+    node = MagicMock()
+    node.id = uuid.uuid4()
+    node.ssh_username = ssh_username
+    node.ssh_password_enc = ssh_password_enc
+    node.ssh_key_enc = ssh_key_enc
+    node.ssh_auth_mode = ssh_auth_mode
+    return node
+
+
+def _group(name="prod", ssh_username="guser", ssh_password_enc=None, ssh_key_enc=None, ssh_auth_mode=None):
+    g = MagicMock()
+    g.name = name
+    g.ssh_username = ssh_username
+    g.ssh_password_enc = ssh_password_enc
+    g.ssh_key_enc = ssh_key_enc
+    g.ssh_auth_mode = ssh_auth_mode
+    return g
+
+
+def _platform_row(value, is_encrypted=False):
+    row = MagicMock()
+    row.value = value
+    row.is_encrypted = is_encrypted
+    return row
+
+
+def test_sync_node_level_credentials():
+    from fleet_platform.services.credential_resolver import resolve_node_credentials_sync
+    node = _node(ssh_username="admin", ssh_password_enc=encrypt_secret("pw"))
+    db = MagicMock()
+    result = resolve_node_credentials_sync(node, db)
+    assert result["credential_source"] == "node"
+    assert result["ssh_user"] == "admin"
+    assert result["ssh_password"] == "pw"
+    db.execute.assert_not_called()
+
+
+def test_sync_group_level_credentials():
+    from fleet_platform.services.credential_resolver import resolve_node_credentials_sync
+    node = _node()
+    group = _group(name="prod", ssh_username="guser", ssh_password_enc=encrypt_secret("gpw"))
+    db = _sync_db(group)
+    result = resolve_node_credentials_sync(node, db)
+    assert result["credential_source"] == "group:prod"
+    assert result["ssh_user"] == "guser"
+    assert result["ssh_password"] == "gpw"
+
+
+def test_sync_global_fallback():
+    from fleet_platform.services.credential_resolver import resolve_node_credentials_sync
+    node = _node()
+    encrypted_pw = _fernet().encrypt(b"secretpass").decode()
+    db = _sync_db(None, _platform_row("deploy"), _platform_row(encrypted_pw, is_encrypted=True))
+    result = resolve_node_credentials_sync(node, db)
+    assert result["credential_source"] == "global"
+    assert result["ssh_user"] == "deploy"
+    assert result["ssh_password"] == "secretpass"
+
+
+def test_sync_node_key_auth_mode():
+    from fleet_platform.services.credential_resolver import resolve_node_credentials_sync
+    node = _node(ssh_username="admin", ssh_key_enc=encrypt_secret("KEYDATA"), ssh_auth_mode="key")
+    result = resolve_node_credentials_sync(node, MagicMock())
+    assert result["auth_mode"] == "key"
+    assert result["ssh_key"] == "KEYDATA"

--- a/tests/unit/test_playbook_credentials_b279.py
+++ b/tests/unit/test_playbook_credentials_b279.py
@@ -1,0 +1,61 @@
+"""Unit tests for auto-resolved playbook credentials + source banner (#279)."""
+import tempfile
+from pathlib import Path
+
+
+def _host(hostname, ip, ssh_user, ssh_password="", ssh_key="", auth_mode="password", source="node"):
+    return {
+        "hostname": hostname,
+        "ip": ip,
+        "ssh_user": ssh_user,
+        "ssh_password": ssh_password,
+        "ssh_key": ssh_key,
+        "auth_mode": auth_mode,
+        "credential_source": source,
+    }
+
+
+def test_inventory_writes_per_host_user_and_password():
+    from fleet_platform.workers.playbook_tasks import _write_static_inventory
+    with tempfile.TemporaryDirectory() as tmp:
+        hosts = [
+            _host("web01", "10.0.0.5", "admin", ssh_password="pw1", source="group:prod"),
+            _host("db01", "10.0.0.9", "root", ssh_password="pw2", source="node"),
+        ]
+        inv_path = _write_static_inventory(tmp, hosts)
+        content = Path(inv_path).read_text()
+    assert "web01 ansible_host=10.0.0.5 ansible_user=admin" in content
+    assert "ansible_ssh_pass=pw1" in content
+    assert "db01 ansible_host=10.0.0.9 ansible_user=root" in content
+    assert "ansible_ssh_pass=pw2" in content
+
+
+def test_inventory_key_auth_writes_key_file_not_password():
+    from fleet_platform.workers.playbook_tasks import _write_static_inventory
+    with tempfile.TemporaryDirectory() as tmp:
+        hosts = [_host("k01", "10.0.0.1", "admin", ssh_key="PRIVKEY", auth_mode="key", source="node")]
+        inv_path = _write_static_inventory(tmp, hosts)
+        content = Path(inv_path).read_text()
+    assert "ansible_ssh_private_key_file=" in content
+    assert "ansible_ssh_pass" not in content
+    # The key material is written to a 0600 file, never inline in the inventory
+    assert "PRIVKEY" not in content
+
+
+def test_inventory_file_is_not_world_readable():
+    from fleet_platform.workers.playbook_tasks import _write_static_inventory
+    with tempfile.TemporaryDirectory() as tmp:
+        inv_path = _write_static_inventory(tmp, [_host("h", "1.2.3.4", "u", ssh_password="p")])
+        mode = Path(inv_path).stat().st_mode & 0o077
+    assert mode == 0, "inventory holds secrets and must not be group/other-readable"
+
+
+def test_credential_source_banner_lists_each_host():
+    from fleet_platform.workers.playbook_tasks import _credential_source_banner
+    hosts = [
+        _host("web01", "10.0.0.5", "admin", source="group:prod"),
+        _host("db01", "10.0.0.9", "root", source="node"),
+    ]
+    banner = _credential_source_banner(hosts)
+    assert "web01" in banner and "10.0.0.5" in banner and "group:prod" in banner
+    assert "db01" in banner and "node" in banner

--- a/tests/unit/test_playbook_tasks.py
+++ b/tests/unit/test_playbook_tasks.py
@@ -4,9 +4,14 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
+def _host(hostname, ip, user, password="", source="node"):
+    return {"hostname": hostname, "ip": ip, "ssh_user": user, "ssh_password": password,
+            "ssh_key": "", "auth_mode": "password", "credential_source": source}
+
+
 def test_write_static_inventory_single_host(tmp_path):
     from fleet_platform.workers.playbook_tasks import _write_static_inventory
-    inv_path = _write_static_inventory(str(tmp_path), [("mac-01", "10.0.1.11", "admin")])
+    inv_path = _write_static_inventory(str(tmp_path), [_host("mac-01", "10.0.1.11", "admin")])
     content = Path(inv_path).read_text()
     assert "[targets]" in content
     assert "mac-01 ansible_host=10.0.1.11 ansible_user=admin" in content
@@ -14,7 +19,7 @@ def test_write_static_inventory_single_host(tmp_path):
 
 def test_write_static_inventory_multiple_hosts(tmp_path):
     from fleet_platform.workers.playbook_tasks import _write_static_inventory
-    hosts = [("mac-01", "10.0.1.11", "admin"), ("mac-02", "10.0.1.12", "admin")]
+    hosts = [_host("mac-01", "10.0.1.11", "admin"), _host("mac-02", "10.0.1.12", "admin")]
     inv_path = _write_static_inventory(str(tmp_path), hosts)
     content = Path(inv_path).read_text()
     assert "mac-01 ansible_host=10.0.1.11" in content


### PR DESCRIPTION
## Summary
Playbook runs no longer prompt for SSH credentials. The worker resolves credentials **per host** (node override → primary group → global) and reports the source in the run output.

- New `resolve_node_credentials_sync()` (sync twin of the async resolver) for the Celery worker.
- Per-host inventory: `ansible_user` + `ansible_ssh_pass`, or a 0600 key file + `ansible_ssh_private_key_file` for key auth. Global `ANSIBLE_USER/PASSWORD` env removed.
- Credential-source banner prepended to job output: `web01 (10.0.0.5) ← group:prod`.
- Secrets no longer pass through Celery task args. `ssh_username/ssh_password` remain optional API override (source `manual`).
- Run modal: SSH fields replaced with an explanatory note.

## Tests
- Unit: sync resolver (node/group/global), per-host inventory creds, key-file-not-inline, 0600 perms, source banner
- Updated existing inventory tests to the new per-host dict signature
- Full unit suite: **836 passed**; frontend build: **0 type errors**

Stacked on #278. Closes #279