### PR TITLE
docs: RAG + LLM + Agentic architecture concept guide

### DIFF
--- a/docs/rag-llm-agentic-architecture.html
+++ b/docs/rag-llm-agentic-architecture.html
@@ -1,0 +1,1004 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>kri RAG + Agentic LLM — Complete Visual Guide</title>
+<style>
+:root {
+  --bg: #F9FAFB;
+  --card: #FFFFFF;
+  --text: #111827;
+  --text2: #4B5563;
+  --border: #E5E7EB;
+  --accent: #444CE7;
+  --accent-bg: #e0e9ff;
+  --success: #16A34A;
+  --warning: #D97706;
+  --error: #DC2626;
+  --purple: #7c3aed;
+  --teal: #0d9488;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:var(--bg);color:var(--text);font-size:14px;line-height:1.6}
+
+header{background:var(--card);border-bottom:1px solid var(--border);padding:20px 48px;display:flex;align-items:center;gap:16px}
+.header-icon{width:40px;height:40px;background:#1a1a3e;border-radius:10px;display:flex;align-items:center;justify-content:center;font-size:18px;flex-shrink:0}
+header h1{font-size:20px;font-weight:700;color:var(--text)}
+header p{font-size:13px;color:var(--text2)}
+
+.tabs{display:flex;border-bottom:1px solid var(--border);background:var(--card);padding:0 48px;position:sticky;top:0;z-index:100;overflow-x:auto;scrollbar-width:none}
+.tabs::-webkit-scrollbar{display:none}
+.tab{padding:13px 18px;cursor:pointer;font-size:13.5px;font-weight:500;color:var(--text2);border-bottom:2px solid transparent;margin-bottom:-1px;white-space:nowrap;transition:color .15s;user-select:none;display:flex;align-items:center;gap:6px}
+.tab:hover{color:var(--text)}
+.tab.active{color:var(--accent);border-bottom-color:var(--accent);font-weight:600}
+.tab-num{font-size:11px;background:#F3F4F6;color:#6B7280;border-radius:99px;padding:1px 6px;font-weight:600}
+.tab.active .tab-num{background:var(--accent-bg);color:var(--accent)}
+
+.content{padding:40px 56px 80px}
+.tab-panel{display:none}
+.tab-panel.active{display:block;animation:fadeUp .2s ease}
+@keyframes fadeUp{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
+
+.section-title{font-size:22px;font-weight:700;color:var(--text);margin-bottom:6px}
+.section-desc{font-size:14px;color:var(--text2);margin-bottom:28px;line-height:1.7}
+
+.card{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:22px;box-shadow:0 1px 3px rgba(0,0,0,.06);margin-bottom:16px}
+h2{font-size:15px;font-weight:600;color:var(--text);margin-bottom:10px}
+h3{font-size:13px;font-weight:600;color:var(--text);margin-bottom:6px}
+p{color:var(--text2);font-size:13.5px;margin-bottom:10px}
+p:last-child{margin-bottom:0}
+
+code{font-family:'SF Mono','Fira Code',monospace;font-size:11.5px;background:#F3F4F6;color:#1F2937;padding:1px 5px;border-radius:3px;border:1px solid #E5E7EB}
+pre{background:#111827;color:#E5E7EB;padding:14px 16px;border-radius:8px;font-size:12px;font-family:'SF Mono','Fira Code',monospace;overflow-x:auto;margin:10px 0;line-height:1.75}
+pre .c{color:#6B7280;font-style:italic}
+pre .k{color:#93C5FD}
+pre .s{color:#6EE7B7}
+pre .v{color:#FCD34D}
+pre .f{color:#F9A8D4}
+
+.badge{display:inline-flex;align-items:center;padding:2px 8px;border-radius:99px;font-size:11px;font-weight:600}
+.b-blue{background:#dbeafe;color:#1d4ed8}
+.b-green{background:#dcfce7;color:#166534}
+.b-amber{background:#fef3c7;color:#92400e}
+.b-red{background:#fee2e2;color:#991b1b}
+.b-purple{background:#ede9fe;color:#6d28d9}
+.b-gray{background:#F3F4F6;color:#374151}
+.b-teal{background:#ccfbf1;color:#134e4a}
+
+.grid-2{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+.grid-3{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}
+.grid-4{display:grid;grid-template-columns:repeat(4,1fr);gap:10px}
+
+.step{display:flex;align-items:flex-start;gap:14px;padding:16px 0;border-bottom:1px solid var(--border)}
+.step:last-child{border-bottom:none}
+.step-num{width:28px;height:28px;border-radius:50%;background:#eff6ff;color:var(--accent);font-weight:700;font-size:12px;display:flex;align-items:center;justify-content:center;flex-shrink:0;border:1.5px solid #bfdbfe}
+.step-title{font-weight:600;font-size:13.5px;color:var(--text)}
+.step-desc{color:var(--text2);font-size:12.5px;margin-top:2px}
+
+.alert{padding:11px 14px;border-radius:6px;font-size:13px;border-left:3px solid;margin:12px 0;line-height:1.5}
+.alert-info{background:#eff6ff;border-color:var(--accent);color:#1e40af}
+.alert-warn{background:#fffbeb;border-color:var(--warning);color:#78350f}
+.alert-green{background:#f0fdf4;border-color:var(--success);color:#14532d}
+.alert-red{background:#fef2f2;border-color:var(--error);color:#7f1d1d}
+
+.diagram{background:#fff;border:1px solid var(--border);border-radius:10px;overflow:hidden;margin:18px 0}
+.diagram-title{background:#F9FAFB;border-bottom:1px solid var(--border);padding:9px 16px;font-size:11px;font-weight:600;color:var(--text2);text-transform:uppercase;letter-spacing:.05em}
+.diagram > svg{display:block;width:100%;height:auto}
+
+.concept{display:flex;gap:14px;padding:14px 0;border-bottom:1px solid #F3F4F6}
+.concept:last-child{border-bottom:none}
+.concept-icon{width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0;border:1px solid var(--border)}
+.concept-name{font-weight:600;font-size:13.5px;color:var(--text)}
+.concept-desc{font-size:12.5px;color:var(--text2);margin-top:2px}
+
+table{width:100%;border-collapse:collapse;font-size:12.5px}
+th{text-align:left;padding:8px 12px;background:#F9FAFB;border-bottom:2px solid var(--border);font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--text2);font-weight:600}
+td{padding:9px 12px;border-bottom:1px solid #F3F4F6;vertical-align:top;color:var(--text2)}
+td:first-child{font-family:'SF Mono',monospace;color:var(--accent);font-size:11.5px}
+tr:last-child td{border-bottom:none}
+tr:hover td{background:#FAFAFA}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="header-icon">
+    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" style="flex-shrink:0">
+      <circle cx="11" cy="11" r="9" stroke="#444CE7" stroke-width="1.8"/>
+      <circle cx="11" cy="11" r="4" fill="#444CE7"/>
+      <line x1="11" y1="2" x2="11" y2="6" stroke="#93C5FD" stroke-width="1.5"/>
+      <line x1="11" y1="16" x2="11" y2="20" stroke="#93C5FD" stroke-width="1.5"/>
+      <line x1="2" y1="11" x2="6" y2="11" stroke="#93C5FD" stroke-width="1.5"/>
+      <line x1="16" y1="11" x2="20" y2="11" stroke="#93C5FD" stroke-width="1.5"/>
+    </svg>
+  </div>
+  <div>
+    <h1>kri RAG + Agentic LLM — Complete Visual Guide</h1>
+    <p>Embeddings · Hybrid Retrieval · Context Assembly · Multi-Model Routing · Agentic Control Loop · Safety Stack</p>
+  </div>
+</header>
+
+<div class="tabs" id="tabs">
+  <div class="tab active" onclick="switchTab('p1')"><span class="tab-num">1</span> RAG / Embeddings</div>
+  <div class="tab" onclick="switchTab('p2')"><span class="tab-num">2</span> LLM Assistant</div>
+  <div class="tab" onclick="switchTab('p3')"><span class="tab-num">3</span> Agentic Control</div>
+</div>
+
+<div class="content">
+
+<!-- ══════════════════════════════════════════════════════════
+     TAB 1 — RAG / EMBEDDINGS
+══════════════════════════════════════════════════════════ -->
+<div class="tab-panel active" id="panel-p1">
+
+  <div class="section-title">RAG / Embeddings — Ingest, Store, Retrieve</div>
+  <div class="section-desc">kri embeds four source types into pgvector and retrieves relevant chunks using <strong>Hybrid BM25 + Vector search fused by Reciprocal Rank Fusion (RRF)</strong>. Every chunk carries a <code>[src: …]</code> provenance tag so the LLM can cite its source. Reindexing is Celery-beat scheduled on the <code>maintenance</code> queue.</div>
+
+  <!-- Pipeline diagram -->
+  <div class="diagram">
+    <div class="diagram-title">RAG Ingest → Embed → Store → Retrieve Pipeline — Animated</div>
+    <svg viewBox="0 0 920 310" xmlns="http://www.w3.org/2000/svg">
+      <rect width="920" height="310" fill="#F8FAFC"/>
+
+      <!-- SOURCES BOX -->
+      <rect x="20" y="30" width="150" height="250" rx="10" fill="#1a1a3e" stroke="#444CE7" stroke-width="2"/>
+      <text x="95" y="55" text-anchor="middle" font-size="12" font-weight="700" fill="#fff">Sources</text>
+
+      <rect x="34" y="68" width="122" height="36" rx="6" fill="rgba(68,76,231,.25)" stroke="rgba(68,76,231,.5)" stroke-width="1"/>
+      <text x="95" y="84" text-anchor="middle" font-size="10" font-weight="600" fill="#c7d2fe">Nodes</text>
+      <text x="95" y="98" text-anchor="middle" font-size="9" fill="#818cf8">1 chunk / node</text>
+
+      <rect x="34" y="112" width="122" height="36" rx="6" fill="rgba(13,148,136,.25)" stroke="rgba(13,148,136,.5)" stroke-width="1"/>
+      <text x="95" y="128" text-anchor="middle" font-size="10" font-weight="600" fill="#5eead4">Playbooks</text>
+      <text x="95" y="142" text-anchor="middle" font-size="9" fill="#2dd4bf">1 chunk / play</text>
+
+      <rect x="34" y="156" width="122" height="36" rx="6" fill="rgba(124,58,237,.25)" stroke="rgba(124,58,237,.5)" stroke-width="1"/>
+      <text x="95" y="172" text-anchor="middle" font-size="10" font-weight="600" fill="#c4b5fd">Salt States</text>
+      <text x="95" y="186" text-anchor="middle" font-size="9" fill="#a78bfa">1 chunk / state-id</text>
+
+      <rect x="34" y="200" width="122" height="36" rx="6" fill="rgba(217,119,6,.25)" stroke="rgba(217,119,6,.5)" stroke-width="1"/>
+      <text x="95" y="216" text-anchor="middle" font-size="10" font-weight="600" fill="#fcd34d">Drift Records</text>
+      <text x="95" y="230" text-anchor="middle" font-size="9" fill="#fbbf24">1 chunk / report</text>
+
+      <!-- CHUNKERS BOX -->
+      <rect x="210" y="30" width="160" height="250" rx="10" fill="#fff" stroke="#E5E7EB" stroke-width="1.5"/>
+      <text x="290" y="55" text-anchor="middle" font-size="12" font-weight="700" fill="#111827">Chunkers</text>
+
+      <rect x="224" y="68" width="132" height="32" rx="5" fill="#F3F4F6"/>
+      <text x="290" y="82" text-anchor="middle" font-size="9" font-weight="600" fill="#374151">chunk_node()</text>
+      <text x="290" y="94" text-anchor="middle" font-size="8" fill="#4B5563">hostname, ip, status, group</text>
+
+      <rect x="224" y="108" width="132" height="32" rx="5" fill="#F3F4F6"/>
+      <text x="290" y="122" text-anchor="middle" font-size="9" font-weight="600" fill="#374151">chunk_playbook()</text>
+      <text x="290" y="134" text-anchor="middle" font-size="8" fill="#4B5563">per-play name + tasks</text>
+
+      <rect x="224" y="148" width="132" height="32" rx="5" fill="#F3F4F6"/>
+      <text x="290" y="162" text-anchor="middle" font-size="9" font-weight="600" fill="#374151">chunk_salt_state()</text>
+      <text x="290" y="174" text-anchor="middle" font-size="8" fill="#4B5563">per top-level state ID</text>
+
+      <rect x="224" y="188" width="132" height="32" rx="5" fill="#F3F4F6"/>
+      <text x="290" y="202" text-anchor="middle" font-size="9" font-weight="600" fill="#374151">chunk_drift_record()</text>
+      <text x="290" y="214" text-anchor="middle" font-size="8" fill="#4B5563">missing/extra/mismatches</text>
+
+      <text x="290" y="248" text-anchor="middle" font-size="9" fill="#4B5563">All chunks tagged</text>
+      <text x="290" y="260" text-anchor="middle" font-size="9" font-weight="600" fill="#444CE7">[src: type/id]</text>
+      <text x="290" y="272" text-anchor="middle" font-size="9" fill="#4B5563">content-hash dedup</text>
+
+      <!-- EMBED BOX -->
+      <rect x="410" y="50" width="160" height="210" rx="10" fill="#fff" stroke="#E5E7EB" stroke-width="1.5"/>
+      <text x="490" y="75" text-anchor="middle" font-size="12" font-weight="700" fill="#111827">embed_texts()</text>
+
+      <rect x="424" y="88" width="132" height="28" rx="5" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+      <text x="490" y="101" text-anchor="middle" font-size="9" font-weight="600" fill="#1d4ed8">nomic-embed-text-v1.5</text>
+      <text x="490" y="112" text-anchor="middle" font-size="8" fill="#3b82f6">768-dim vectors</text>
+
+      <rect x="424" y="124" width="132" height="28" rx="5" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+      <text x="490" y="137" text-anchor="middle" font-size="9" font-weight="600" fill="#166534">search_document: prefix</text>
+      <text x="490" y="148" text-anchor="middle" font-size="8" fill="#16A34A">asymmetric retrieval</text>
+
+      <rect x="424" y="160" width="132" height="28" rx="5" fill="#fef3c7" stroke="#fde68a" stroke-width="1"/>
+      <text x="490" y="173" text-anchor="middle" font-size="9" font-weight="600" fill="#92400e">Batch 64 + Retry ×3</text>
+      <text x="490" y="184" text-anchor="middle" font-size="8" fill="#78350f">exponential backoff</text>
+
+      <rect x="424" y="196" width="132" height="28" rx="5" fill="#fdf4ff" stroke="#e9d5ff" stroke-width="1"/>
+      <text x="490" y="209" text-anchor="middle" font-size="9" font-weight="600" fill="#6d28d9">Dim Validation</text>
+      <text x="490" y="220" text-anchor="middle" font-size="8" fill="#7c3aed">fails loud on mismatch</text>
+
+      <text x="490" y="248" text-anchor="middle" font-size="9" fill="#4B5563">Upsert: delete-changed</text>
+      <text x="490" y="260" text-anchor="middle" font-size="9" fill="#4B5563">+ insert · orphan sweep</text>
+
+      <!-- PGVECTOR BOX — main actor -->
+      <rect x="610" y="40" width="150" height="230" rx="10" fill="#1a1a3e" stroke="#444CE7" stroke-width="2.5"/>
+      <text x="685" y="65" text-anchor="middle" font-size="12" font-weight="700" fill="#fff">pgvector</text>
+      <text x="685" y="80" text-anchor="middle" font-size="9" fill="#a4bbfc">fleet_embeddings</text>
+
+      <!-- Radar ping on pgvector -->
+      <circle cx="685" cy="145" r="8" fill="#444CE7">
+        <animate attributeName="opacity" values="1;0.6;1" dur="2s" repeatCount="indefinite"/>
+      </circle>
+      <circle cx="685" cy="145" r="8" fill="none" stroke="#444CE7" stroke-width="2">
+        <animate attributeName="r" values="8;22;8" dur="2s" repeatCount="indefinite"/>
+        <animate attributeName="opacity" values="0.8;0;0.8" dur="2s" repeatCount="indefinite"/>
+      </circle>
+      <circle cx="685" cy="145" r="8" fill="none" stroke="#444CE7" stroke-width="1">
+        <animate attributeName="r" values="8;36;8" dur="2s" repeatCount="indefinite" begin="0.4s"/>
+        <animate attributeName="opacity" values="0.5;0;0.5" dur="2s" repeatCount="indefinite" begin="0.4s"/>
+      </circle>
+
+      <rect x="624" y="165" width="122" height="24" rx="5" fill="rgba(68,76,231,.2)" stroke="rgba(68,76,231,.4)" stroke-width="1"/>
+      <text x="685" y="180" text-anchor="middle" font-size="9" font-weight="600" fill="#c7d2fe">HNSW Index (045)</text>
+
+      <rect x="624" y="196" width="122" height="24" rx="5" fill="rgba(68,76,231,.2)" stroke="rgba(68,76,231,.4)" stroke-width="1"/>
+      <text x="685" y="211" text-anchor="middle" font-size="9" font-weight="600" fill="#c7d2fe">BM25 FTS Index</text>
+
+      <text x="685" y="240" text-anchor="middle" font-size="9" fill="#a4bbfc">Upsert: plan_upsert()</text>
+      <text x="685" y="253" text-anchor="middle" font-size="9" fill="#a4bbfc">Sweep: plan_sweep()</text>
+
+      <!-- RETRIEVAL BOX -->
+      <rect x="800" y="50" width="104" height="210" rx="10" fill="#fff" stroke="#E5E7EB" stroke-width="1.5"/>
+      <text x="852" y="73" text-anchor="middle" font-size="11" font-weight="700" fill="#111827">Retrieval</text>
+
+      <rect x="814" y="83" width="76" height="32" rx="5" fill="#dbeafe"/>
+      <text x="852" y="97" text-anchor="middle" font-size="9" font-weight="600" fill="#1d4ed8">BM25</text>
+      <text x="852" y="109" text-anchor="middle" font-size="8" fill="#1e40af">Postgres FTS</text>
+
+      <rect x="814" y="122" width="76" height="32" rx="5" fill="#ede9fe"/>
+      <text x="852" y="136" text-anchor="middle" font-size="9" font-weight="600" fill="#6d28d9">Vector</text>
+      <text x="852" y="148" text-anchor="middle" font-size="8" fill="#7c3aed">cosine sim</text>
+
+      <rect x="814" y="161" width="76" height="28" rx="5" fill="#f0fdf4"/>
+      <text x="852" y="173" text-anchor="middle" font-size="9" font-weight="600" fill="#166534">RRF Fusion</text>
+      <text x="852" y="183" text-anchor="middle" font-size="8" fill="#16A34A">k=60</text>
+
+      <text x="852" y="208" text-anchor="middle" font-size="9" fill="#4B5563">search_query:</text>
+      <text x="852" y="220" text-anchor="middle" font-size="9" fill="#4B5563">prefix at query</text>
+      <text x="852" y="236" text-anchor="middle" font-size="9" font-weight="600" fill="#444CE7">top-k chunks</text>
+      <text x="852" y="250" text-anchor="middle" font-size="9" fill="#4B5563">→ LLM context</text>
+
+      <!-- Beat schedule label -->
+      <rect x="20" y="286" width="890" height="16" rx="4" fill="none"/>
+      <text x="460" y="298" text-anchor="middle" font-size="10" fill="#4B5563">Celery-Beat maintenance queue: nodes every 5 min · playbooks every 15 min · drift every 5 min</text>
+
+      <!-- Connectors — horizontal L-bends, no diagonals -->
+      <!-- Sources → Chunkers -->
+      <line x1="170" y1="155" x2="210" y2="155" stroke="#444CE7" stroke-width="1.5"/>
+      <!-- Chunkers → Embed -->
+      <line x1="370" y1="155" x2="410" y2="155" stroke="#444CE7" stroke-width="1.5"/>
+      <!-- Embed → pgvector -->
+      <line x1="570" y1="155" x2="610" y2="155" stroke="#444CE7" stroke-width="1.5"/>
+      <!-- pgvector → Retrieval -->
+      <line x1="760" y1="155" x2="800" y2="155" stroke="#444CE7" stroke-width="1.5"/>
+
+      <!-- Arrowheads -->
+      <polygon points="210,151 202,155 210,159" fill="#444CE7"/>
+      <polygon points="410,151 402,155 410,159" fill="#444CE7"/>
+      <polygon points="610,151 602,155 610,159" fill="#444CE7"/>
+      <polygon points="800,151 792,155 800,159" fill="#444CE7"/>
+
+      <!-- Animated flow dots along the pipeline (exact path matches lines) -->
+      <defs>
+        <path id="pipe1" d="M170,155 L210,155"/>
+        <path id="pipe2" d="M370,155 L410,155"/>
+        <path id="pipe3" d="M570,155 L610,155"/>
+        <path id="pipe4" d="M760,155 L800,155"/>
+      </defs>
+      <circle r="4" fill="#444CE7" opacity="0.9"><animateMotion dur="1.6s" repeatCount="indefinite" begin="0s"><mpath href="#pipe1"/></animateMotion></circle>
+      <circle r="4" fill="#444CE7" opacity="0.9"><animateMotion dur="1.6s" repeatCount="indefinite" begin="0.4s"><mpath href="#pipe2"/></animateMotion></circle>
+      <circle r="4" fill="#444CE7" opacity="0.9"><animateMotion dur="1.6s" repeatCount="indefinite" begin="0.8s"><mpath href="#pipe3"/></animateMotion></circle>
+      <circle r="4" fill="#16A34A" opacity="0.9"><animateMotion dur="1.6s" repeatCount="indefinite" begin="1.2s"><mpath href="#pipe4"/></animateMotion></circle>
+    </svg>
+  </div>
+
+  <!-- Chunking detail -->
+  <div class="grid-2">
+    <div class="card">
+      <h2>Four Source Types, Four Chunkers</h2>
+      <div class="concept">
+        <div class="concept-icon" style="background:#eff6ff">💻</div>
+        <div>
+          <div class="concept-name">chunk_node()</div>
+          <div class="concept-desc">One node = one chunk (profile card). Fields: hostname, node_id, IP, status, group, OS, last_seen. Re-embeds on registration, status change, group change. IP redacted when <code>include_ips=False</code> — same privacy gate as chat context.</div>
+        </div>
+      </div>
+      <div class="concept">
+        <div class="concept-icon" style="background:#f0fdf4">📋</div>
+        <div>
+          <div class="concept-name">chunk_playbook()</div>
+          <div class="concept-desc">One play = one chunk. Captures play name, target hosts, and the list of task names from the YAML. Source ID is <code>path:play_N</code>. Invalid YAML returns empty list silently.</div>
+        </div>
+      </div>
+      <div class="concept">
+        <div class="concept-icon" style="background:#fdf4ff">⚙️</div>
+        <div>
+          <div class="concept-name">chunk_salt_state()</div>
+          <div class="concept-desc">One top-level state ID = one chunk. SLS files are YAML; each root key is a state ID. Body includes path, state ID, and up to 400 chars of the declaration. Source ID is <code>path:state_id</code>.</div>
+        </div>
+      </div>
+      <div class="concept">
+        <div class="concept-icon" style="background:#fffbeb">📊</div>
+        <div>
+          <div class="concept-name">chunk_drift_record()</div>
+          <div class="concept-desc">One drift report = one chunk. Captures node hostname, timestamp, drift score, and up to 10 entries each of missing, extra, and mismatched packages. Source ID is <code>drift:uuid</code>.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Embedding: nomic-embed-text-v1.5</h2>
+      <div class="step">
+        <div class="step-num">1</div>
+        <div><div class="step-title">Task Prefix Application</div><div class="step-desc"><code>search_document:</code> prepended at ingest; <code>search_query:</code> prepended at query time. This asymmetric prefix is required by nomic-embed-text-v1.5 for optimal retrieval — skipping it degrades recall.</div></div>
+      </div>
+      <div class="step">
+        <div class="step-num">2</div>
+        <div><div class="step-title">Batched POST to /v1/embeddings</div><div class="step-desc">64 texts per batch, up to 3 retries with exponential backoff (2s, 4s, 8s) on transport errors. Large reindexes never 413 or time out.</div></div>
+      </div>
+      <div class="step">
+        <div class="step-num">3</div>
+        <div><div class="step-title">Dimension Validation</div><div class="step-desc">Every vector is checked against <code>Vector(768)</code> — the configured column width. A wrong model or endpoint raises <code>EmbeddingDimensionError</code> immediately. No silent corruption.</div></div>
+      </div>
+      <div class="step">
+        <div class="step-num">4</div>
+        <div><div class="step-title">True Upsert + Orphan Sweep</div><div class="step-desc"><code>plan_upsert()</code>: delete rows whose source_id changed hash, then insert fresh. <code>plan_sweep()</code>: delete rows whose source no longer exists (node deleted, playbook removed). The index never accumulates stale embeddings.</div></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Retrieval detail -->
+  <div class="card">
+    <h2>Hybrid Retrieval: BM25 + Vector → RRF Fusion</h2>
+    <div class="grid-3">
+      <div>
+        <h3>BM25 (Postgres FTS)</h3>
+        <p>Full-text search over <code>chunk_text</code> using PostgreSQL's <code>tsvector</code>/<code>tsquery</code>. Excellent at matching exact hostnames, package names, and technical terms that embedding models may treat as semantically similar when they are not.</p>
+      </div>
+      <div>
+        <h3>Vector Cosine Similarity</h3>
+        <p>pgvector HNSW index (migration 045) over the 768-dim nomic vectors. Catches semantic matches — "node is down" matches "offline status" — that BM25 misses. The <code>search_query:</code> prefix ensures the query embedding aligns with the ingestion-time <code>search_document:</code> embedding.</p>
+      </div>
+      <div>
+        <h3>Reciprocal Rank Fusion (k=60)</h3>
+        <p>Each candidate scores <code>1/(60 + rank)</code> from each ranked list. Scores are summed and candidates sorted descending. Deduplicates IDs that appear in both lists. The combined ranking reliably outperforms either signal alone, especially on short, ambiguous fleet queries.</p>
+      </div>
+    </div>
+    <pre><span class="c"># RRF pseudocode from embedding_svc.py</span>
+<span class="k">for</span> ranked_list <span class="k">in</span> [bm25_ids, vector_ids]:
+    <span class="k">for</span> rank, item_id <span class="k">in</span> enumerate(ranked_list, start=<span class="v">1</span>):
+        scores[item_id] += <span class="v">1.0</span> / (k + rank)  <span class="c"># k=60</span>
+<span class="k">return</span> sorted(scores, key=<span class="k">lambda</span> x: -scores[x])  <span class="c"># descending</span></pre>
+  </div>
+
+  <div class="alert alert-info">
+    <strong>Provenance tags are non-negotiable.</strong> Every chunk text begins with <code>[src: type/id]</code> (e.g. <code>[src: node/mm2]</code>, <code>[src: drift:abc123]</code>). The LLM is instructed to cite these tags in its answer. Without them, there is no way to audit which retrieved chunk drove a claim.
+  </div>
+
+  <div class="grid-2">
+    <div class="card">
+      <h2>Beat Schedule — Maintenance Queue</h2>
+      <table>
+        <tr><th>Task</th><th>Interval</th><th>Trigger</th></tr>
+        <tr><td>reindex_nodes</td><td style="color:#111827">5 min</td><td style="color:#4B5563">Node status / group changes</td></tr>
+        <tr><td>reindex_playbooks</td><td style="color:#111827">15 min</td><td style="color:#4B5563">Playbook catalog updates</td></tr>
+        <tr><td>reindex_drift</td><td style="color:#111827">5 min</td><td style="color:#4B5563">New drift reports computed</td></tr>
+        <tr><td>sweep_orphans</td><td style="color:#111827">on reindex</td><td style="color:#4B5563">Source deleted from platform</td></tr>
+      </table>
+    </div>
+    <div class="card">
+      <h2>pgvector Table: fleet_embeddings</h2>
+      <table>
+        <tr><th>Column</th><th>Type / Notes</th></tr>
+        <tr><td>source_type</td><td style="color:#4B5563">node | playbook | salt_state | drift</td></tr>
+        <tr><td>source_id</td><td style="color:#4B5563">Unique key for upsert (path:id form)</td></tr>
+        <tr><td>chunk_text</td><td style="color:#4B5563">Full text with [src:…] tag prefix</td></tr>
+        <tr><td>content_hash</td><td style="color:#4B5563">SHA-256 of body — change detector</td></tr>
+        <tr><td>embedding</td><td style="color:#4B5563">Vector(768) — HNSW index (migration 045)</td></tr>
+        <tr><td>metadata</td><td style="color:#4B5563">JSONB — hostname, path, drift_score, etc.</td></tr>
+      </table>
+    </div>
+  </div>
+
+</div><!-- /panel-p1 -->
+
+<!-- ══════════════════════════════════════════════════════════
+     TAB 2 — LLM ASSISTANT
+══════════════════════════════════════════════════════════ -->
+<div class="tab-panel" id="panel-p2">
+
+  <div class="section-title">LLM Assistant — Context Assembly &amp; Multi-Model Routing</div>
+  <div class="section-desc">Every chat turn assembles a grounded system prompt from four layers — Fleet Snapshot, Node Records, RAG chunks, and pinned Grounding Rules — then routes to the configured model via OpenAI-compat SSE streaming or the native Anthropic SDK. Robustness mechanisms prevent the 500 on bad node data and surface actionable errors from endpoint failures.</div>
+
+  <!-- Context assembly diagram -->
+  <div class="diagram">
+    <div class="diagram-title">Query → Context Assembly → Model → Grounded Answer — Animated</div>
+    <svg viewBox="0 0 920 340" xmlns="http://www.w3.org/2000/svg">
+      <rect width="920" height="340" fill="#F8FAFC"/>
+
+      <!-- Query box -->
+      <rect x="20" y="130" width="110" height="80" rx="10" fill="#1a1a3e" stroke="#444CE7" stroke-width="2"/>
+      <text x="75" y="163" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">Operator</text>
+      <text x="75" y="178" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">Query</text>
+      <text x="75" y="196" text-anchor="middle" font-size="9" fill="#a4bbfc">+ history[−10]</text>
+      <circle cx="108" cy="145" r="5" fill="#444CE7">
+        <animate attributeName="opacity" values="1;0.4;1" dur="1.8s" repeatCount="indefinite"/>
+      </circle>
+
+      <!-- Intent box -->
+      <rect x="175" y="120" width="120" height="100" rx="10" fill="#fff" stroke="#E5E7EB" stroke-width="1.5"/>
+      <text x="235" y="148" text-anchor="middle" font-size="11" font-weight="700" fill="#111827">Intent</text>
+      <text x="235" y="163" text-anchor="middle" font-size="9" fill="#4B5563">fleet_query</text>
+      <text x="235" y="175" text-anchor="middle" font-size="9" fill="#4B5563">salt_state</text>
+      <text x="235" y="187" text-anchor="middle" font-size="9" fill="#4B5563">ansible_playbook</text>
+      <text x="235" y="199" text-anchor="middle" font-size="9" fill="#4B5563">fleet_command</text>
+      <text x="235" y="211" text-anchor="middle" font-size="9" fill="#4B5563">explain</text>
+
+      <!-- Context Assembly — large box -->
+      <rect x="340" y="20" width="280" height="300" rx="10" fill="#fff" stroke="#E5E7EB" stroke-width="1.5"/>
+      <text x="480" y="46" text-anchor="middle" font-size="12" font-weight="700" fill="#111827">build_fleet_context()</text>
+      <text x="480" y="62" text-anchor="middle" font-size="9" fill="#4B5563">System prompt assembled in order:</text>
+
+      <rect x="356" y="72" width="248" height="38" rx="6" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1"/>
+      <text x="480" y="89" text-anchor="middle" font-size="10" font-weight="600" fill="#1d4ed8">1 — Fleet Snapshot</text>
+      <text x="480" y="104" text-anchor="middle" font-size="9" fill="#3b82f6">counts · groups · salt-master · playbooks dir</text>
+
+      <rect x="356" y="118" width="248" height="38" rx="6" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+      <text x="480" y="135" text-anchor="middle" font-size="10" font-weight="600" fill="#166534">2 — Node Records Table</text>
+      <text x="480" y="150" text-anchor="middle" font-size="9" fill="#16A34A">hostname · IP · status · group · last_seen</text>
+
+      <rect x="356" y="164" width="248" height="38" rx="6" fill="#fdf4ff" stroke="#e9d5ff" stroke-width="1"/>
+      <text x="480" y="181" text-anchor="middle" font-size="10" font-weight="600" fill="#6d28d9">3 — RAG Chunks (top-k)</text>
+      <text x="480" y="196" text-anchor="middle" font-size="9" fill="#7c3aed">hybrid BM25+vector·[src:…] citations</text>
+
+      <rect x="356" y="210" width="248" height="58" rx="6" fill="#1a1a3e" stroke="#444CE7" stroke-width="1.5"/>
+      <text x="480" y="230" text-anchor="middle" font-size="10" font-weight="700" fill="#fff">4 — Grounding Rules (PINNED)</text>
+      <text x="480" y="245" text-anchor="middle" font-size="9" fill="#a4bbfc">Node Records are source of truth</text>
+      <text x="480" y="258" text-anchor="middle" font-size="9" fill="#a4bbfc">hostname IS the node name</text>
+      <text x="480" y="271" text-anchor="middle" font-size="9" fill="#a4bbfc">never deflect to the UI</text>
+
+      <text x="480" y="300" text-anchor="middle" font-size="9" fill="#4B5563">Truncation: middle dropped, grounding rules ALWAYS preserved</text>
+      <text x="480" y="312" text-anchor="middle" font-size="9" fill="#4B5563">Token budget gated: estimate_tokens() per section</text>
+
+      <!-- Model box -->
+      <rect x="665" y="100" width="140" height="140" rx="10" fill="#1a1a3e" stroke="#444CE7" stroke-width="2"/>
+      <text x="735" y="127" text-anchor="middle" font-size="12" font-weight="700" fill="#fff">Model</text>
+      <text x="735" y="143" text-anchor="middle" font-size="9" fill="#a4bbfc">call_openai_compat()</text>
+      <text x="735" y="156" text-anchor="middle" font-size="9" fill="#a4bbfc">SSE streaming</text>
+      <text x="735" y="170" text-anchor="middle" font-size="9" fill="#6EE7B7">— or —</text>
+      <text x="735" y="184" text-anchor="middle" font-size="9" fill="#a4bbfc">call_anthropic()</text>
+      <text x="735" y="197" text-anchor="middle" font-size="9" fill="#a4bbfc">native SDK</text>
+      <circle cx="791" cy="120" r="5" fill="#16A34A">
+        <animate attributeName="opacity" values="1;0.3;1" dur="1.5s" repeatCount="indefinite"/>
+      </circle>
+      <circle cx="791" cy="120" r="5" fill="none" stroke="#16A34A" stroke-width="1.5">
+        <animate attributeName="r" values="5;14;5" dur="1.5s" repeatCount="indefinite"/>
+        <animate attributeName="opacity" values="0.7;0;0.7" dur="1.5s" repeatCount="indefinite"/>
+      </circle>
+
+      <!-- Answer box -->
+      <rect x="815" y="130" width="90" height="80" rx="10" fill="#fff" stroke="#E5E7EB" stroke-width="1.5"/>
+      <text x="860" y="158" text-anchor="middle" font-size="11" font-weight="700" fill="#111827">Grounded</text>
+      <text x="860" y="173" text-anchor="middle" font-size="11" font-weight="700" fill="#111827">Answer</text>
+      <text x="860" y="191" text-anchor="middle" font-size="9" fill="#16A34A">+ [src:…] citations</text>
+
+      <!-- Connectors -->
+      <line x1="130" y1="170" x2="175" y2="170" stroke="#444CE7" stroke-width="1.5"/>
+      <polygon points="175,166 167,170 175,174" fill="#444CE7"/>
+
+      <line x1="295" y1="170" x2="340" y2="170" stroke="#444CE7" stroke-width="1.5"/>
+      <polygon points="340,166 332,170 340,174" fill="#444CE7"/>
+
+      <line x1="620" y1="170" x2="665" y2="170" stroke="#444CE7" stroke-width="1.5"/>
+      <polygon points="665,166 657,170 665,174" fill="#444CE7"/>
+
+      <line x1="805" y1="170" x2="815" y2="170" stroke="#16A34A" stroke-width="1.5"/>
+      <polygon points="815,166 807,170 815,174" fill="#16A34A"/>
+
+      <!-- Animated flow dots -->
+      <defs>
+        <path id="qp1" d="M130,170 L175,170"/>
+        <path id="qp2" d="M295,170 L340,170"/>
+        <path id="qp3" d="M620,170 L665,170"/>
+        <path id="qp4" d="M805,170 L815,170"/>
+      </defs>
+      <circle r="4" fill="#444CE7" opacity="0.9"><animateMotion dur="1.4s" repeatCount="indefinite" begin="0s"><mpath href="#qp1"/></animateMotion></circle>
+      <circle r="4" fill="#444CE7" opacity="0.9"><animateMotion dur="1.4s" repeatCount="indefinite" begin="0.35s"><mpath href="#qp2"/></animateMotion></circle>
+      <circle r="4" fill="#444CE7" opacity="0.9"><animateMotion dur="1.4s" repeatCount="indefinite" begin="0.7s"><mpath href="#qp3"/></animateMotion></circle>
+      <circle r="4" fill="#16A34A" opacity="0.9"><animateMotion dur="1.4s" repeatCount="indefinite" begin="1.05s"><mpath href="#qp4"/></animateMotion></circle>
+    </svg>
+  </div>
+
+  <div class="grid-2">
+    <div class="card">
+      <h2>Grounding Rules — Why They Come Last</h2>
+      <p>The system prompt always ends with the <code>## Rules</code> section. This is intentional: when a small-context endpoint forces truncation, <code>_truncate_system_prompt()</code> drops the middle (RAG chunks / node records) but <strong>always preserves the head and tail</strong>. The grounding rules survive even when everything else is cut.</p>
+      <div class="alert alert-info" style="margin-top:8px">
+        <strong>Key rules verbatim from the code:</strong><br>
+        · Node Records are the LIVE, AUTHORITATIVE inventory — source of truth.<br>
+        · A node's hostname IS its name, even if it looks like an IP.<br>
+        · Never tell the operator to "check the kri UI" for data already in context.<br>
+        · Never claim to have executed a command or performed a live action.
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Robustness Mechanisms</h2>
+      <div class="concept">
+        <div class="concept-icon" style="background:#fef2f2">🛡️</div>
+        <div>
+          <div class="concept-name">_sanitize_cell()</div>
+          <div class="concept-desc">Coerces non-str values (IPv4Address, datetime, int, None) to str before building the Markdown node table. Fixed a 500 where node.ip arrived as <code>ipaddress.IPv4Address</code> and .replace() raised AttributeError on every chat query (#633).</div>
+        </div>
+      </div>
+      <div class="concept">
+        <div class="concept-icon" style="background:#fffbeb">⚠️</div>
+        <div>
+          <div class="concept-name">_describe_http_error()</div>
+          <div class="concept-desc">Surfaces the endpoint body (up to 300 chars) in the error message. A 404 adds the hint: "the configured model is not loaded — pick an available model in Settings → LLM." Auth errors say "check the API key."</div>
+        </div>
+      </div>
+      <div class="concept">
+        <div class="concept-icon" style="background:#f0fdf4">🔄</div>
+        <div>
+          <div class="concept-name">Graceful Context Degradation</div>
+          <div class="concept-desc">If context assembly fails (DB unreachable, schema error) the assistant falls back to a minimal prompt and responds. It never 500s the chat endpoint due to a context-building failure.</div>
+        </div>
+      </div>
+      <div class="concept">
+        <div class="concept-icon" style="background:#eff6ff">🧪</div>
+        <div>
+          <div class="concept-name">_validate_response()</div>
+          <div class="concept-desc">Detects common small-model failures: response shorter than 5 chars, echoing the system prompt, and chat-template artifacts (<code>&lt;|im_start|&gt;</code> etc.). Returns a clean error message instead of surfacing garbage to the operator.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Multi-model routing -->
+  <div class="card">
+    <h2>Multi-Model Routing + Auto Health Probing (#636)</h2>
+    <p>kri supports any OpenAI-compatible endpoint (vLLM, Ollama, LM Studio, exo, Groq, Mistral, Together) plus Anthropic's native SDK. Routing is based on the endpoint configured as default, with per-endpoint capability detection to handle provider-specific quirks.</p>
+    <div class="grid-3">
+      <div>
+        <h3>OpenAI-compat (SSE)</h3>
+        <p><code>call_openai_compat()</code> — streaming <code>/v1/chat/completions</code>. Handles per-chunk read timeout (30s silence = abort), thinking-model <code>&lt;think&gt;</code> block stripping, echo detection, and chat-template artifact removal. Stop tokens omitted for thinking models.</p>
+      </div>
+      <div>
+        <h3>Anthropic Native SDK</h3>
+        <p><code>call_anthropic()</code> — uses <code>anthropic.AsyncAnthropic</code> with <code>messages.create()</code>. History passed directly. Returns <code>(content, input_tokens, output_tokens)</code> matching the OpenAI-compat signature so the router is provider-agnostic.</p>
+      </div>
+      <div>
+        <h3>Local exo Models</h3>
+        <p>exo serves local Apple Silicon models (Qwen3, DeepSeek, GLM) via OpenAI-compat at <code>192.168.1.23:52415</code>. The <code>normalize_openai_base_url()</code> helper strips trailing <code>/v1</code> to prevent doubled-prefix bugs (#272). No Tailscale relay — LAN-direct always.</p>
+      </div>
+    </div>
+    <table style="margin-top:12px">
+      <tr><th>Provider / Endpoint</th><th>Route</th><th>Notes</th></tr>
+      <tr><td>OpenAI / Groq / Together</td><td style="color:#111827">call_openai_compat</td><td style="color:#4B5563">Bearer token auth, streaming</td></tr>
+      <tr><td>Ollama / LM Studio / vLLM</td><td style="color:#111827">call_openai_compat</td><td style="color:#4B5563">No auth required locally</td></tr>
+      <tr><td>exo (local)</td><td style="color:#111827">call_openai_compat</td><td style="color:#4B5563">192.168.1.23:52415 LAN direct</td></tr>
+      <tr><td>Anthropic Claude</td><td style="color:#111827">call_anthropic</td><td style="color:#4B5563">Native SDK, tool_use format</td></tr>
+    </table>
+  </div>
+
+  <div class="grid-2">
+    <div class="card">
+      <h2>Intent Classification</h2>
+      <p>Intent is classified before context assembly and selects the task addendum appended to the system prompt. The addendum tells the model how to frame its response.</p>
+      <table>
+        <tr><th>Intent</th><th>Addendum instruction</th></tr>
+        <tr><td>fleet_query</td><td style="color:#4B5563">Answer only from Fleet Snapshot + Node Records; never speculate</td></tr>
+        <tr><td>salt_state</td><td style="color:#4B5563">Generate a complete .sls file in a code block</td></tr>
+        <tr><td>ansible_playbook</td><td style="color:#4B5563">Generate a complete YAML playbook</td></tr>
+        <tr><td>fleet_command</td><td style="color:#4B5563">Suggest exact salt module call with arg explanations</td></tr>
+        <tr><td>explain</td><td style="color:#4B5563">What it does, side effects, idempotency</td></tr>
+      </table>
+    </div>
+    <div class="card">
+      <h2>History Budget</h2>
+      <p>The last 10 conversation turns are included in the <code>messages</code> array (both OpenAI-compat and Anthropic). This is a pragmatic cap: enough for multi-turn diagnosis sessions, cheap enough that even a 4k-context model can accommodate it.</p>
+      <p>Context length awareness: <code>call_openai_compat()</code> accepts <code>model_context_length</code> and clamps <code>max_tokens</code> to the model's window. The system prompt budget is <code>(ctx − max_tokens) × 4 chars</code>, ensuring the output region is always reserved.</p>
+      <div class="alert alert-warn" style="margin-top:8px">IP redaction: when <code>include_ips=False</code> is set in platform settings, every IPv4 address in the assembled context is replaced with <code>[REDACTED_IP]</code> before the prompt leaves the backend. Same gate applies at embed time.</div>
+    </div>
+  </div>
+
+</div><!-- /panel-p2 -->
+
+<!-- ══════════════════════════════════════════════════════════
+     TAB 3 — AGENTIC CONTROL
+══════════════════════════════════════════════════════════ -->
+<div class="tab-panel" id="panel-p3">
+
+  <div class="section-title">Agentic Control — Tool-Calling Loop + Safety Stack</div>
+  <div class="section-desc">kri's agentic layer lets the LLM propose actions against the fleet. The LLM is an <strong>untrusted actor</strong> — it never executes directly. A layered safety stack intercepts every tool call: denylist, dry-run, operator confirmation, then admin-inbox approval of the verbatim resolved action. READ tools auto-run from cached DB data; WRITE tools require the full two-layer human approval.</div>
+
+  <!-- Agent loop diagram -->
+  <div class="diagram">
+    <div class="diagram-title">Agent Loop — LLM → Tool-Call → Dual Approval Gate → Execute — Animated</div>
+    <svg viewBox="0 0 940 380" xmlns="http://www.w3.org/2000/svg">
+      <rect width="940" height="380" fill="#F8FAFC"/>
+
+      <!-- LLM box -->
+      <rect x="20" y="140" width="120" height="100" rx="10" fill="#1a1a3e" stroke="#444CE7" stroke-width="2"/>
+      <text x="80" y="168" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">LLM</text>
+      <text x="80" y="183" text-anchor="middle" font-size="9" fill="#a4bbfc">Emits tool_calls</text>
+      <text x="80" y="198" text-anchor="middle" font-size="9" fill="#a4bbfc">or tool_use or</text>
+      <text x="80" y="213" text-anchor="middle" font-size="9" fill="#6EE7B7">JSON in content</text>
+      <circle cx="128" cy="155" r="5" fill="#444CE7">
+        <animate attributeName="opacity" values="1;0.4;1" dur="1.8s" repeatCount="indefinite"/>
+      </circle>
+      <circle cx="128" cy="155" r="5" fill="none" stroke="#444CE7" stroke-width="1.5">
+        <animate attributeName="r" values="5;15;5" dur="1.8s" repeatCount="indefinite"/>
+        <animate attributeName="opacity" values="0.7;0;0.7" dur="1.8s" repeatCount="indefinite"/>
+      </circle>
+
+      <!-- Adapter box -->
+      <rect x="185" y="120" width="130" height="140" rx="10" fill="#fff" stroke="#E5E7EB" stroke-width="1.5"/>
+      <text x="250" y="147" text-anchor="middle" font-size="11" font-weight="700" fill="#111827">Tool Adapter</text>
+      <rect x="199" y="157" width="102" height="24" rx="4" fill="#dbeafe"/>
+      <text x="250" y="173" text-anchor="middle" font-size="9" font-weight="600" fill="#1d4ed8">native tool_calls</text>
+      <rect x="199" y="187" width="102" height="24" rx="4" fill="#ede9fe"/>
+      <text x="250" y="203" text-anchor="middle" font-size="9" font-weight="600" fill="#6d28d9">Anthropic tool_use</text>
+      <rect x="199" y="217" width="102" height="24" rx="4" fill="#fef3c7"/>
+      <text x="250" y="231" text-anchor="middle" font-size="9" font-weight="600" fill="#92400e">JSON/content fallback</text>
+      <text x="250" y="246" text-anchor="middle" font-size="8" fill="#78350f">&lt;|python_tag|&gt;{json}</text>
+
+      <!-- Router: READ vs WRITE -->
+      <rect x="360" y="100" width="120" height="180" rx="10" fill="#fff" stroke="#E5E7EB" stroke-width="1.5"/>
+      <text x="420" y="126" text-anchor="middle" font-size="11" font-weight="700" fill="#111827">Tool Router</text>
+
+      <rect x="374" y="136" width="92" height="48" rx="6" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1"/>
+      <text x="420" y="157" text-anchor="middle" font-size="10" font-weight="700" fill="#166534">READ</text>
+      <text x="420" y="170" text-anchor="middle" font-size="8" fill="#166534">node status</text>
+      <text x="420" y="181" text-anchor="middle" font-size="8" fill="#166534">processes·drift</text>
+
+      <rect x="374" y="192" width="92" height="48" rx="6" fill="#fef2f2" stroke="#fecaca" stroke-width="1"/>
+      <text x="420" y="213" text-anchor="middle" font-size="10" font-weight="700" fill="#991b1b">WRITE</text>
+      <text x="420" y="226" text-anchor="middle" font-size="8" fill="#991b1b">process control</text>
+      <text x="420" y="237" text-anchor="middle" font-size="8" fill="#991b1b">service actions</text>
+
+      <text x="420" y="270" text-anchor="middle" font-size="9" fill="#4B5563">Per-endpoint</text>
+      <text x="420" y="282" text-anchor="middle" font-size="9" fill="#4B5563">capability detect</text>
+
+      <!-- READ auto-run box -->
+      <rect x="530" y="96" width="118" height="80" rx="10" fill="#f0fdf4" stroke="#16A34A" stroke-width="1.5"/>
+      <text x="589" y="120" text-anchor="middle" font-size="10" font-weight="700" fill="#166534">Auto-Run</text>
+      <text x="589" y="134" text-anchor="middle" font-size="9" fill="#166534">cached DB data</text>
+      <text x="589" y="148" text-anchor="middle" font-size="9" fill="#166534">no approval</text>
+      <text x="589" y="162" text-anchor="middle" font-size="9" fill="#166534">needed</text>
+
+      <!-- WRITE safety stack -->
+      <rect x="530" y="190" width="118" height="156" rx="10" fill="#fff" stroke="#E5E7EB" stroke-width="1.5"/>
+      <text x="589" y="212" text-anchor="middle" font-size="10" font-weight="700" fill="#111827">Safety Stack</text>
+
+      <rect x="542" y="220" width="94" height="22" rx="4" fill="#fee2e2"/>
+      <text x="589" y="235" text-anchor="middle" font-size="9" font-weight="600" fill="#991b1b">Denylist Check</text>
+
+      <rect x="542" y="248" width="94" height="22" rx="4" fill="#fef3c7"/>
+      <text x="589" y="263" text-anchor="middle" font-size="9" font-weight="600" fill="#92400e">Dry-Run Preview</text>
+
+      <rect x="542" y="276" width="94" height="22" rx="4" fill="#dbeafe"/>
+      <text x="589" y="291" text-anchor="middle" font-size="9" font-weight="600" fill="#1d4ed8">LLM Summarize</text>
+
+      <rect x="542" y="304" width="94" height="22" rx="4" fill="#ede9fe"/>
+      <text x="589" y="319" text-anchor="middle" font-size="9" font-weight="600" fill="#6d28d9">Operator Confirm</text>
+
+      <rect x="542" y="332" width="94" height="22" rx="4" fill="#1a1a3e" stroke="#444CE7" stroke-width="1"/>
+      <text x="589" y="347" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">Admin Inbox</text>
+
+      <!-- Execute box -->
+      <rect x="698" y="250" width="130" height="100" rx="10" fill="#1a1a3e" stroke="#444CE7" stroke-width="2"/>
+      <text x="763" y="277" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">Execute</text>
+      <text x="763" y="292" text-anchor="middle" font-size="9" fill="#a4bbfc">run_salt_cmd()</text>
+      <text x="763" y="307" text-anchor="middle" font-size="9" fill="#a4bbfc">result tracking</text>
+      <text x="763" y="322" text-anchor="middle" font-size="9" fill="#6EE7B7">full audit</text>
+      <circle cx="815" cy="263" r="5" fill="#16A34A">
+        <animate attributeName="opacity" values="1;0.3;1" dur="1.5s" repeatCount="indefinite" begin="0.5s"/>
+      </circle>
+      <circle cx="815" cy="263" r="5" fill="none" stroke="#16A34A" stroke-width="1.5">
+        <animate attributeName="r" values="5;16;5" dur="1.5s" repeatCount="indefinite" begin="0.5s"/>
+        <animate attributeName="opacity" values="0.7;0;0.7" dur="1.5s" repeatCount="indefinite" begin="0.5s"/>
+      </circle>
+
+      <!-- Observe box -->
+      <rect x="698" y="120" width="130" height="80" rx="10" fill="#fff" stroke="#E5E7EB" stroke-width="1.5"/>
+      <text x="763" y="147" text-anchor="middle" font-size="11" font-weight="700" fill="#111827">Observe</text>
+      <text x="763" y="163" text-anchor="middle" font-size="9" fill="#4B5563">Tool result → context</text>
+      <text x="763" y="178" text-anchor="middle" font-size="9" fill="#4B5563">Continue loop</text>
+
+      <!-- Observe → LLM back arrow -->
+      <!-- L-bend: right edge of Observe → top of LLM -->
+      <path d="M698,160 L80,160 L80,140" fill="none" stroke="#4B5563" stroke-width="1" stroke-dasharray="4,3"/>
+      <polygon points="76,140 80,132 84,140" fill="#4B5563"/>
+      <text x="380" y="153" text-anchor="middle" font-size="9" fill="#4B5563">continue loop / next turn</text>
+
+      <!-- Connectors -->
+      <line x1="140" y1="190" x2="185" y2="190" stroke="#444CE7" stroke-width="1.5"/>
+      <polygon points="185,186 177,190 185,194" fill="#444CE7"/>
+
+      <line x1="315" y1="190" x2="360" y2="190" stroke="#444CE7" stroke-width="1.5"/>
+      <polygon points="360,186 352,190 360,194" fill="#444CE7"/>
+
+      <!-- Router READ → auto-run -->
+      <line x1="480" y1="160" x2="530" y2="136" fill="none" stroke="#16A34A" stroke-width="1.5"/>
+      <polygon points="530,132 522,134 527,142" fill="#16A34A"/>
+
+      <!-- Router WRITE → safety -->
+      <line x1="480" y1="216" x2="530" y2="268" fill="none" stroke="#DC2626" stroke-width="1.5"/>
+      <polygon points="527,268 524,260 534,265" fill="#DC2626"/>
+
+      <!-- READ auto-run → Observe -->
+      <line x1="648" y1="136" x2="698" y2="136" stroke="#16A34A" stroke-width="1.5"/>
+      <polygon points="698,132 690,136 698,140" fill="#16A34A"/>
+
+      <!-- Safety stack → Execute -->
+      <line x1="648" y1="300" x2="698" y2="300" stroke="#444CE7" stroke-width="1.5"/>
+      <polygon points="698,296 690,300 698,304" fill="#444CE7"/>
+
+      <!-- Execute → Observe (vertical) -->
+      <line x1="763" y1="250" x2="763" y2="200" stroke="#444CE7" stroke-width="1.5"/>
+      <polygon points="759,200 763,192 767,200" fill="#444CE7"/>
+
+      <!-- Animated flow dots -->
+      <defs>
+        <path id="ap1" d="M140,190 L185,190"/>
+        <path id="ap2" d="M315,190 L360,190"/>
+        <path id="ap3" d="M648,136 L698,136"/>
+        <path id="ap4" d="M648,300 L698,300"/>
+        <path id="ap5" d="M763,250 L763,200"/>
+      </defs>
+      <circle r="4" fill="#444CE7" opacity="0.9"><animateMotion dur="1.5s" repeatCount="indefinite" begin="0s"><mpath href="#ap1"/></animateMotion></circle>
+      <circle r="4" fill="#444CE7" opacity="0.9"><animateMotion dur="1.5s" repeatCount="indefinite" begin="0.4s"><mpath href="#ap2"/></animateMotion></circle>
+      <circle r="4" fill="#16A34A" opacity="0.9"><animateMotion dur="1.5s" repeatCount="indefinite" begin="0.8s"><mpath href="#ap3"/></animateMotion></circle>
+      <circle r="4" fill="#444CE7" opacity="0.9"><animateMotion dur="1.5s" repeatCount="indefinite" begin="1.2s"><mpath href="#ap4"/></animateMotion></circle>
+      <circle r="4" fill="#16A34A" opacity="0.9"><animateMotion dur="1.5s" repeatCount="indefinite" begin="1.6s"><mpath href="#ap5"/></animateMotion></circle>
+    </svg>
+  </div>
+
+  <!-- Defense-in-depth diagram -->
+  <div class="diagram">
+    <div class="diagram-title">Defense-in-Depth Safety Layers — WRITE Tool Path</div>
+    <svg viewBox="0 0 920 220" xmlns="http://www.w3.org/2000/svg">
+      <rect width="920" height="220" fill="#F8FAFC"/>
+
+      <!-- Layers as horizontal bands -->
+      <!-- Layer 1: Denylist -->
+      <rect x="20" y="30" width="160" height="160" rx="10" fill="#fef2f2" stroke="#DC2626" stroke-width="1.5"/>
+      <text x="100" y="58" text-anchor="middle" font-size="11" font-weight="700" fill="#991b1b">Denylist</text>
+      <text x="100" y="76" text-anchor="middle" font-size="9" fill="#7f1d1d">sshd · salt-minion</text>
+      <text x="100" y="90" text-anchor="middle" font-size="9" fill="#7f1d1d">salt-master · exo</text>
+      <text x="100" y="104" text-anchor="middle" font-size="9" fill="#7f1d1d">launchd · kernel_task</text>
+      <text x="100" y="118" text-anchor="middle" font-size="9" fill="#7f1d1d">windowserver · syslogd</text>
+      <text x="100" y="134" text-anchor="middle" font-size="9" fill="#7f1d1d">networkd · configd</text>
+      <text x="100" y="148" text-anchor="middle" font-size="9" fill="#7f1d1d">powerd · securityd</text>
+      <text x="100" y="162" text-anchor="middle" font-size="9" fill="#7f1d1d">trustd · opendirectoryd</text>
+      <text x="100" y="178" text-anchor="middle" font-size="9" font-weight="600" fill="#DC2626">→ 403 immediately</text>
+
+      <!-- Layer 2: Allowlist + Dry-Run -->
+      <rect x="205" y="30" width="155" height="160" rx="10" fill="#fffbeb" stroke="#D97706" stroke-width="1.5"/>
+      <text x="282" y="58" text-anchor="middle" font-size="11" font-weight="700" fill="#92400e">Dry-Run Preview</text>
+      <text x="282" y="76" text-anchor="middle" font-size="9" fill="#78350f">Resolve full invocation:</text>
+      <text x="282" y="90" text-anchor="middle" font-size="9" fill="#78350f">(function, args, node)</text>
+      <text x="282" y="108" text-anchor="middle" font-size="9" fill="#78350f">Show operator EXACTLY</text>
+      <text x="282" y="122" text-anchor="middle" font-size="9" fill="#78350f">what would execute</text>
+      <text x="282" y="140" text-anchor="middle" font-size="9" fill="#78350f">SIGTERM=15 SIGSTOP=17</text>
+      <text x="282" y="154" text-anchor="middle" font-size="9" fill="#78350f">SIGCONT=19 (macOS)</text>
+      <text x="282" y="172" text-anchor="middle" font-size="9" font-weight="600" fill="#D97706">SIGKILL always blocked</text>
+
+      <!-- Layer 3: LLM Summarize + Operator Confirm -->
+      <rect x="380" y="30" width="175" height="160" rx="10" fill="#eff6ff" stroke="#444CE7" stroke-width="1.5"/>
+      <text x="467" y="58" text-anchor="middle" font-size="11" font-weight="700" fill="#1e40af">Operator Confirm</text>
+      <text x="467" y="76" text-anchor="middle" font-size="9" fill="#1e3a8a">LLM generates</text>
+      <text x="467" y="90" text-anchor="middle" font-size="9" fill="#1e3a8a">plain-language summary</text>
+      <text x="467" y="108" text-anchor="middle" font-size="9" fill="#1e3a8a">of proposed action</text>
+      <text x="467" y="122" text-anchor="middle" font-size="9" fill="#1e3a8a">Operator reviews +</text>
+      <text x="467" y="136" text-anchor="middle" font-size="9" fill="#1e3a8a">confirms intent</text>
+      <text x="467" y="152" text-anchor="middle" font-size="9" fill="#1e3a8a">Layer 1 of 2-layer</text>
+      <text x="467" y="166" text-anchor="middle" font-size="9" fill="#1e3a8a">human approval</text>
+
+      <!-- Layer 4: Admin Inbox -->
+      <rect x="576" y="30" width="180" height="160" rx="10" fill="#1a1a3e" stroke="#444CE7" stroke-width="2"/>
+      <text x="666" y="58" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">Admin Inbox</text>
+      <text x="666" y="76" text-anchor="middle" font-size="9" fill="#a4bbfc">Admin approves the</text>
+      <text x="666" y="90" text-anchor="middle" font-size="9" fill="#a4bbfc">VERBATIM resolved</text>
+      <text x="666" y="104" text-anchor="middle" font-size="9" fill="#6EE7B7">(function, args, node)</text>
+      <text x="666" y="118" text-anchor="middle" font-size="9" fill="#a4bbfc">NOT the prose summary</text>
+      <text x="666" y="136" text-anchor="middle" font-size="9" fill="#a4bbfc">PendingAction row with</text>
+      <text x="666" y="150" text-anchor="middle" font-size="9" fill="#a4bbfc">approval_token (32-byte)</text>
+      <text x="666" y="164" text-anchor="middle" font-size="9" fill="#a4bbfc">15-min TTL + expiry</text>
+      <text x="666" y="178" text-anchor="middle" font-size="9" font-weight="600" fill="#6EE7B7">Layer 2 of 2-layer</text>
+
+      <!-- Layer 5: Audit -->
+      <rect x="778" y="30" width="125" height="160" rx="10" fill="#f0fdf4" stroke="#16A34A" stroke-width="1.5"/>
+      <text x="840" y="58" text-anchor="middle" font-size="11" font-weight="700" fill="#166534">Audit + Execute</text>
+      <text x="840" y="76" text-anchor="middle" font-size="9" fill="#14532d">run_salt_cmd()</text>
+      <text x="840" y="90" text-anchor="middle" font-size="9" fill="#14532d">via guarded</text>
+      <text x="840" y="104" text-anchor="middle" font-size="9" fill="#14532d">Salt dispatch</text>
+      <text x="840" y="122" text-anchor="middle" font-size="9" fill="#14532d">Result → Celery</text>
+      <text x="840" y="136" text-anchor="middle" font-size="9" fill="#14532d">callback tracking</text>
+      <text x="840" y="154" text-anchor="middle" font-size="9" fill="#14532d">Full audit log</text>
+      <text x="840" y="168" text-anchor="middle" font-size="9" fill="#14532d">per execution</text>
+
+      <!-- Connectors between layers -->
+      <line x1="180" y1="110" x2="205" y2="110" stroke="#374151" stroke-width="1.5"/>
+      <polygon points="205,106 197,110 205,114" fill="#374151"/>
+      <line x1="360" y1="110" x2="380" y2="110" stroke="#374151" stroke-width="1.5"/>
+      <polygon points="380,106 372,110 380,114" fill="#374151"/>
+      <line x1="555" y1="110" x2="576" y2="110" stroke="#374151" stroke-width="1.5"/>
+      <polygon points="576,106 568,110 576,114" fill="#374151"/>
+      <line x1="756" y1="110" x2="778" y2="110" stroke="#16A34A" stroke-width="1.5"/>
+      <polygon points="778,106 770,110 778,114" fill="#16A34A"/>
+
+      <!-- Animated dots through layers -->
+      <defs>
+        <path id="dl1" d="M180,110 L205,110"/>
+        <path id="dl2" d="M360,110 L380,110"/>
+        <path id="dl3" d="M555,110 L576,110"/>
+        <path id="dl4" d="M756,110 L778,110"/>
+      </defs>
+      <circle r="4" fill="#DC2626" opacity="0.9"><animateMotion dur="1.8s" repeatCount="indefinite" begin="0s"><mpath href="#dl1"/></animateMotion></circle>
+      <circle r="4" fill="#D97706" opacity="0.9"><animateMotion dur="1.8s" repeatCount="indefinite" begin="0.45s"><mpath href="#dl2"/></animateMotion></circle>
+      <circle r="4" fill="#444CE7" opacity="0.9"><animateMotion dur="1.8s" repeatCount="indefinite" begin="0.9s"><mpath href="#dl3"/></animateMotion></circle>
+      <circle r="4" fill="#16A34A" opacity="0.9"><animateMotion dur="1.8s" repeatCount="indefinite" begin="1.35s"><mpath href="#dl4"/></animateMotion></circle>
+    </svg>
+  </div>
+
+  <div class="grid-2">
+    <div class="card">
+      <h2>Backend-Agnostic Tool Adapters</h2>
+      <p>The LLM is an untrusted actor that may use any of three tool-call formats. kri normalizes them all to <code>(function, args, node)</code> before routing.</p>
+      <div class="concept">
+        <div class="concept-icon" style="background:#dbeafe">🔧</div>
+        <div>
+          <div class="concept-name">Native tool_calls</div>
+          <div class="concept-desc">OpenAI / vLLM / Ollama format — structured JSON in the <code>tool_calls</code> field of the completion. Per-endpoint capability detection determines if the endpoint supports this format.</div>
+        </div>
+      </div>
+      <div class="concept">
+        <div class="concept-icon" style="background:#ede9fe">🤖</div>
+        <div>
+          <div class="concept-name">Anthropic tool_use</div>
+          <div class="concept-desc">Claude's native format — tool invocations appear as <code>tool_use</code> content blocks in the response. The Anthropic SDK route handles this natively.</div>
+        </div>
+      </div>
+      <div class="concept">
+        <div class="concept-icon" style="background:#fef3c7">📄</div>
+        <div>
+          <div class="concept-name">JSON / Content Fallback</div>
+          <div class="concept-desc">exo emits Llama-format tool calls as <code>&lt;|python_tag|&gt;{json}</code> inside the content string. kri parses and normalizes this universally — any serving stack (exo, mlx, vLLM, llama.cpp) that emits JSON-in-content is handled.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Protected Targets — Hardcoded Denylist</h2>
+      <p>These targets cannot be stopped, suspended, or disabled remotely under any circumstance. The check happens at the validation layer before the approval gate is even reached — a 403 is returned immediately.</p>
+      <div class="grid-2" style="gap:8px;margin-top:10px">
+        <div>
+          <span class="badge b-red" style="margin:2px">salt-minion</span>
+          <span class="badge b-red" style="margin:2px">salt-master</span>
+          <span class="badge b-red" style="margin:2px">sshd</span>
+          <span class="badge b-red" style="margin:2px">exo</span>
+          <span class="badge b-red" style="margin:2px">launchd</span>
+          <span class="badge b-red" style="margin:2px">kernel_task</span>
+        </div>
+        <div>
+          <span class="badge b-red" style="margin:2px">windowserver</span>
+          <span class="badge b-red" style="margin:2px">syslogd</span>
+          <span class="badge b-red" style="margin:2px">networkd</span>
+          <span class="badge b-red" style="margin:2px">configd</span>
+          <span class="badge b-red" style="margin:2px">securityd</span>
+          <span class="badge b-red" style="margin:2px">trustd</span>
+          <span class="badge b-red" style="margin:2px">opendirectoryd</span>
+          <span class="badge b-red" style="margin:2px">powerd</span>
+          <span class="badge b-red" style="margin:2px">mdnsresponder</span>
+        </div>
+      </div>
+      <div class="alert alert-red" style="margin-top:10px">
+        <code>process_kill</code> (SIGKILL) is in <code>FORBIDDEN</code> — blocked entirely, not gated. No approval flow can authorize it. SIGTERM (15), SIGSTOP (17), and SIGCONT (19) are the only signals available, and only for non-protected targets.
+      </div>
+    </div>
+  </div>
+
+  <div class="grid-2">
+    <div class="card">
+      <h2>READ Tools — Auto-Run from Cache</h2>
+      <p>READ tools query cached DB data — no network call to the node, no Salt dispatch. They execute in the same request cycle and return results directly into the LLM's next context window.</p>
+      <table>
+        <tr><th>Tool</th><th>Data Source</th></tr>
+        <tr><td>get_node_status</td><td style="color:#4B5563">Node table — online/offline, last_seen</td></tr>
+        <tr><td>list_processes</td><td style="color:#4B5563">TimescaleDB hypertable — per-process mem/CPU</td></tr>
+        <tr><td>get_drift_report</td><td style="color:#4B5563">DriftRecord table — score, missing, extra, mismatches</td></tr>
+        <tr><td>get_alerts</td><td style="color:#4B5563">Alert table — active alerts by node</td></tr>
+      </table>
+      <div class="alert alert-green" style="margin-top:10px">READ tools never touch the node. They are safe to auto-run — no approval required. The LLM observes the result and may decide to propose a WRITE tool as a follow-on.</div>
+    </div>
+
+    <div class="card">
+      <h2>Runaway Safety + Feature Flag</h2>
+      <div class="step">
+        <div class="step-num">1</div>
+        <div><div class="step-title">Rate Limiting</div><div class="step-desc">Node action endpoints are rate-limited (#616). A runaway agent loop cannot flood the approval system or the Salt API.</div></div>
+      </div>
+      <div class="step">
+        <div class="step-num">2</div>
+        <div><div class="step-title">Max Steps / Wall / Tokens</div><div class="step-desc">Per-session caps on loop iterations, wall-clock time, and token consumption. An agent that loops without progress is aborted automatically.</div></div>
+      </div>
+      <div class="step">
+        <div class="step-num">3</div>
+        <div><div class="step-title">Redis Inference Semaphore</div><div class="step-desc">At most N concurrent agent sessions per node to prevent parallel conflicting actions. Redis semaphore released on session completion or timeout.</div></div>
+      </div>
+      <div class="step">
+        <div class="step-num">4</div>
+        <div><div class="step-title">Feature Flag</div><div class="step-desc">The entire agentic subsystem is guarded by a feature flag in platform settings. Disabled by default — operators opt in explicitly.</div></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Durable State Machine: AgentSession / AgentAction</h2>
+    <p>Agent sessions and their constituent actions are persisted off the async event loop. This means:</p>
+    <div class="grid-3">
+      <div>
+        <h3>Session Durability</h3>
+        <p><code>AgentSession</code> records track the full multi-turn loop. A session survives a worker restart — the loop can be resumed or inspected after a crash.</p>
+      </div>
+      <div>
+        <h3>Action Immutability</h3>
+        <p>Once an <code>AgentAction</code> row is committed with its resolved <code>(function, args, node)</code>, it cannot be modified. The admin approves this exact record — not a mutable prose description.</p>
+      </div>
+      <div>
+        <h3>PendingAction TTL</h3>
+        <p>Approval tokens expire after 15 minutes. An approval not acted on becomes <code>expired</code>. The operator must re-request a fresh action — preventing stale approvals from executing later.</p>
+      </div>
+    </div>
+    <pre><span class="c"># PendingAction states: pending → approved → executed</span>
+<span class="c">#                      pending → rejected</span>
+<span class="c">#                      pending → expired (beat task sweeps every minute)</span>
+<span class="c">#</span>
+<span class="c"># FORBIDDEN forever (never routed to approval):</span>
+FORBIDDEN = frozenset({<span class="s">"process_kill"</span>})  <span class="c"># SIGKILL</span>
+
+<span class="c"># Require approval flow:</span>
+DESTRUCTIVE = frozenset({
+    <span class="s">"process_stop"</span>,    <span class="c"># SIGTERM=15</span>
+    <span class="s">"process_suspend"</span>, <span class="c"># SIGSTOP=17</span>
+    <span class="s">"service_stop"</span>,
+    <span class="s">"service_disable"</span>,
+})</pre>
+  </div>
+
+  <div class="card">
+    <h2>Local Model Assignment by Task</h2>
+    <p>exo serves Apple Silicon models at <code>192.168.1.23:52415</code>. Each agentic task type is routed to the model best suited for that workload — avoiding the cost of frontier API calls for fleet-local operations.</p>
+    <table>
+      <tr><th>Task Type</th><th>Model</th><th>Rationale</th></tr>
+      <tr><td>Tool calling / function selection</td><td style="color:#111827">Qwen3-Next-80B-A3B</td><td style="color:#4B5563">Strong structured output, MoE efficiency</td></tr>
+      <tr><td>Planning / reasoning</td><td style="color:#111827">DeepSeek / GLM</td><td style="color:#4B5563">Multi-step reasoning capability</td></tr>
+      <tr><td>Code generation (SLS / playbook)</td><td style="color:#111827">Qwen3-Coder</td><td style="color:#4B5563">Code-specialized fine-tune</td></tr>
+      <tr><td>Anthropic endpoints</td><td style="color:#111827">Claude (API)</td><td style="color:#4B5563">Native tool_use, best grounding</td></tr>
+    </table>
+  </div>
+
+  <!-- Status callout -->
+  <div class="alert alert-green" style="margin-top:24px;font-size:13.5px">
+    <strong>Current Status (2026-06-09):</strong>
+    RAG pipeline and LLM assistant are <strong>live in production</strong> — embeddings indexed, hybrid retrieval active, multi-model routing operational.
+    The agentic control design has passed review by 4 principals. Architecture is finalized; <strong>Phase 0 implementation is next</strong> — READ tools first, then the WRITE/approval gate, then the full durable session state machine.
+  </div>
+
+</div><!-- /panel-p3 -->
+
+</div><!-- /content -->
+
+<script>
+function switchTab(id) {
+  document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+  document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+  document.getElementById('panel-' + id).classList.add('active');
+  const idx = {'p1':0,'p2':1,'p3':2}[id];
+  document.querySelectorAll('.tab')[idx].classList.add('active');
+}
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Self-contained HTML concept guide (animated SVG) documenting kri's RAG/Embeddings + LLM + Agentic architecture — the doc you asked for. 3 tabs, 5 animated SVG diagrams, house concept-guide style, no remote assets, no forbidden colors. Companion narrative blog written to ~/Documents/blogs/2026-06-09-kri-agentic-fleet-assistant/ (external, not in repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)