### PR TITLE
[REVIEW] Ansible: salt_master re-applies ACL + restarts salt-api on already-provisioned master (#659)

### DIFF
--- a/playbooks/roles/salt_master/README.md
+++ b/playbooks/roles/salt_master/README.md
@@ -1,0 +1,132 @@
+# salt_master Ansible Role
+
+Installs, configures, and maintains `salt-master` + `salt-api` on a macOS or Linux host.
+
+Designed to be **fully idempotent** — running the role against an already-provisioned host is safe. Only changed files trigger handler restarts.
+
+---
+
+## What the role does
+
+1. **Installs** Salt from the bundled air-gapped `.pkg` (macOS) or the SaltProject apt/yum repo (Linux).
+2. **Configures** `/etc/salt/master.d/kri.conf` — interface bind, pillar/file roots, presence events, reactor, `netapi_enable_clients`, and the `external_auth` ACL that authorises kri workers via PAM.
+3. **Configures** `/etc/salt/master.d/salt-api.conf` — `rest_cherrypy` on `{{ salt_api_port }}` (default 8080) with TLS.
+4. **Writes PKI** — copies the pre-generated master keypair so all existing minions continue trusting the master without re-acceptance.
+5. **Creates the kri service account** (`krisalt`) and sets the salt-api password via PAM.
+6. **Generates a self-signed TLS cert/key** for salt-api (idempotent — only once).
+7. **Manages the service** via launchd plists (macOS) or systemd units (Linux).
+8. **Verifies** salt-master (port 4505) and salt-api (port 8080) are accepting connections, then performs a live `POST /login` eauth probe to confirm the `external_auth` ACL is active.
+
+---
+
+## Sudo / become prerequisite
+
+**The SSH user on the target host must have passwordless `sudo` (or you must pass the sudo password at runtime).**
+
+Every privileged task in this role (`template`, `file`, `shell`, `user`, `command`) uses `become: true`. The role does **not** embed any hardcoded privilege-escalation password.
+
+### Option A — passwordless sudo (recommended for mm1)
+
+Add to `/etc/sudoers` (or `/etc/sudoers.d/ansible`) on the target:
+
+```
+dk ALL=(ALL) NOPASSWD: ALL
+```
+
+Then run without any extra flag:
+
+```bash
+ansible-playbook playbooks/deploy_salt_master_mm1.yml \
+  -i playbooks/inventory/hosts.ini \
+  -e "kri_salt_api_password=<secure-password>"
+```
+
+Or via the unified CLI:
+
+```bash
+scripts/kri saltmaster install 192.168.1.64
+```
+
+### Option B — interactive sudo prompt
+
+If passwordless sudo is not configured, pass the become password at runtime:
+
+```bash
+ansible-playbook playbooks/deploy_salt_master_mm1.yml \
+  -i playbooks/inventory/hosts.ini \
+  -e "kri_salt_api_password=<secure-password>" \
+  --ask-become-pass
+```
+
+---
+
+## Re-applying the role against mm1 (already-provisioned host)
+
+Running the role again when nothing has changed is a no-op — all tasks report `ok`, no handlers fire, no services restart.
+
+When `kri.conf` or `salt-api.conf` changes (e.g. after adding a new function to the `external_auth` ACL), the role:
+
+1. Writes the updated config (reports `changed`).
+2. Triggers **both** `Restart salt-master` and `Restart salt-api` handlers (salt-api reads master.d config at startup, so both must restart for `external_auth` changes to take effect).
+3. Waits for both ports to come back up.
+4. Probes `POST /login` to confirm the new ACL is live.
+
+**Exact re-apply command (mm1, macOS):**
+
+```bash
+ansible-playbook playbooks/deploy_salt_master_mm1.yml \
+  -i playbooks/inventory/hosts.ini \
+  -e "kri_salt_api_password=<secure-password>"
+```
+
+Or via the unified CLI (interactive mode — prompts for IP and password):
+
+```bash
+scripts/kri saltmaster install 192.168.1.64
+```
+
+---
+
+## Role variables
+
+All variables are defined in `defaults/main.yml` with documented descriptions.
+
+| Variable | Default | Description |
+|---|---|---|
+| `salt_version` | `3007.14` | Salt version to install. Must match fleet minions. |
+| `salt_api_port` | `8080` | salt-api HTTPS port. |
+| `salt_api_user` | `krisalt` | PAM service account for kri workers. |
+| `kri_salt_api_password` | `changeme-set-in-vault` | **Must be overridden.** Pass via `-e` or Vault. |
+| `salt_master_interface` | `0.0.0.0` | Interface salt-master binds on. |
+| `salt_api_ssl_crt` | `/etc/salt/pki/api/salt-api.crt` | TLS cert path. Auto-generated if absent. |
+| `salt_api_ssl_key` | `/etc/salt/pki/api/salt-api.key` | TLS key path. Auto-generated if absent. |
+| `salt_api_verify` | `true` | Set to `false` to skip the `/login` readiness probe. |
+
+---
+
+## Post-install verification (`tasks/verify.yml`)
+
+The role always runs `tasks/verify.yml` at the end:
+
+1. `wait_for port=4505` — salt-master ZeroMQ bus ready (60s timeout).
+2. `wait_for port={{ salt_api_port }}` — salt-api HTTPS ready (60s timeout).
+3. `uri POST /login eauth=pam` — proves `external_auth` ACL is live. A 200 response with a token means kri workers can authenticate.
+
+To skip the login probe (e.g. during a CI dry-run where `kri_salt_api_password` is not set):
+
+```bash
+ansible-playbook playbooks/deploy_salt_master_mm1.yml \
+  -i playbooks/inventory/hosts.ini \
+  -e "kri_salt_api_password=<pw>" \
+  -e "salt_api_verify=false"
+```
+
+---
+
+## external_auth ACL sync requirement
+
+The `external_auth` function list in `templates/kri-master.conf.j2` **must stay in sync** with `_DEFAULT_SALT_FUNCTIONS` in `fleet_platform/services/platform_settings_svc.py`. Any function added to the app-side allowlist must also appear in the ACL, or salt-api will return a 401 for that function.
+
+After adding a new function:
+1. Update both files in the same commit.
+2. Re-apply the role against all salt-master hosts (the verification probe will confirm the new function is authorised).

--- a/playbooks/roles/salt_master/tasks/configure.yml
+++ b/playbooks/roles/salt_master/tasks/configure.yml
@@ -27,7 +27,9 @@
     group: wheel
     mode: "0644"
   become: true
-  notify: Restart salt-master
+  notify:
+    - Restart salt-master
+    - Restart salt-api
 
 - name: Write salt-api configuration
   template:

--- a/playbooks/roles/salt_master/tasks/main.yml
+++ b/playbooks/roles/salt_master/tasks/main.yml
@@ -57,3 +57,5 @@
 - name: Configure service (Linux systemd)
   include_tasks: service_systemd.yml
   when: _salt_os != 'macos'
+
+- import_tasks: verify.yml

--- a/playbooks/roles/salt_master/tasks/verify.yml
+++ b/playbooks/roles/salt_master/tasks/verify.yml
@@ -1,0 +1,42 @@
+---
+# tasks/verify.yml — post-restart verification for salt-master and salt-api
+#
+# Included last from main.yml (after service_macos.yml / service_systemd.yml).
+# Waits for both services to be network-ready, then performs an optional
+# salt-api eauth login probe to confirm external_auth ACL is live.
+#
+# To skip the login probe (e.g. when kri_salt_api_password is not set):
+#   ansible-playbook ... -e salt_api_verify=false
+
+- name: Wait for salt-master ZeroMQ port to be ready
+  wait_for:
+    port: 4505
+    host: 127.0.0.1
+    timeout: 60
+  become: false
+
+- name: Wait for salt-api HTTPS port to be ready
+  wait_for:
+    port: "{{ salt_api_port }}"
+    host: 127.0.0.1
+    timeout: 60
+  become: false
+
+- name: Probe salt-api /login to verify external_auth ACL is live
+  uri:
+    url: "https://127.0.0.1:{{ salt_api_port }}/login"
+    method: POST
+    body_format: json
+    body:
+      username: "{{ salt_api_user }}"
+      password: "{{ kri_salt_api_password }}"
+      eauth: pam
+    validate_certs: false
+    status_code: 200
+  register: salt_api_login_result
+  failed_when: >
+    salt_api_login_result.status != 200
+    or (salt_api_login_result.json.return | default([]) | length == 0)
+    or not (salt_api_login_result.json.return[0].token | default(''))
+  when: salt_api_verify | default(true) | bool
+  become: false

--- a/tests/unit/test_salt_master_role_reapply_659.py
+++ b/tests/unit/test_salt_master_role_reapply_659.py
@@ -1,0 +1,262 @@
+# tests/unit/test_salt_master_role_reapply_659.py
+"""Tests for #659: salt-master Ansible role hardening — re-apply idempotency,
+dual handler notification on kri.conf change, post-restart verification.
+
+All file paths are resolved relative to this file so the tests work in any
+working directory (source-contract pattern used across this test suite).
+"""
+
+from pathlib import Path
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Paths — always relative to this file, never hardcoded absolute paths
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ROLE_ROOT = _REPO_ROOT / "playbooks" / "roles" / "salt_master"
+_CONFIGURE_YML = _ROLE_ROOT / "tasks" / "configure.yml"
+_HANDLERS_YML = _ROLE_ROOT / "handlers" / "main.yml"
+_VERIFY_YML = _ROLE_ROOT / "tasks" / "verify.yml"
+_MAIN_YML = _ROLE_ROOT / "tasks" / "main.yml"
+_README_MD = _ROLE_ROOT / "README.md"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_yaml(path: Path) -> list:
+    """Load a YAML file; return list of documents (safe_load_all)."""
+    docs = list(yaml.safe_load_all(path.read_text()))
+    # safe_load_all yields a single list for non-multi-document files
+    if len(docs) == 1 and isinstance(docs[0], list):
+        return docs[0]
+    return [d for d in docs if d is not None]
+
+
+def _find_task(tasks: list, name_fragment: str) -> dict | None:
+    """Return the first task whose 'name' contains name_fragment (case-insensitive)."""
+    for task in tasks:
+        if isinstance(task, dict) and name_fragment.lower() in str(task.get("name", "")).lower():
+            return task
+    return None
+
+
+# ---------------------------------------------------------------------------
+# 1. YAML parse sanity — all touched files must be valid YAML
+# ---------------------------------------------------------------------------
+
+
+def test_configure_yml_parses():
+    tasks = _load_yaml(_CONFIGURE_YML)
+    assert tasks, "configure.yml must not be empty"
+
+
+def test_handlers_yml_parses():
+    handlers = _load_yaml(_HANDLERS_YML)
+    assert handlers, "handlers/main.yml must not be empty"
+
+
+def test_verify_yml_parses():
+    tasks = _load_yaml(_VERIFY_YML)
+    assert tasks, "verify.yml must not be empty"
+
+
+def test_main_yml_parses():
+    tasks = _load_yaml(_MAIN_YML)
+    assert tasks, "tasks/main.yml must not be empty"
+
+
+# ---------------------------------------------------------------------------
+# 2. configure.yml: kri.conf task must notify BOTH Restart handlers
+# ---------------------------------------------------------------------------
+
+
+def test_kri_conf_task_notifies_restart_salt_master():
+    """'Write kri salt-master configuration' must notify 'Restart salt-master'."""
+    tasks = _load_yaml(_CONFIGURE_YML)
+    task = _find_task(tasks, "Write kri salt-master configuration")
+    assert task is not None, "'Write kri salt-master configuration' task not found in configure.yml"
+
+    notify = task.get("notify", [])
+    # notify may be a string (single) or list
+    if isinstance(notify, str):
+        notify = [notify]
+    assert "Restart salt-master" in notify, (
+        "kri.conf template task must notify 'Restart salt-master'; "
+        f"current notify list: {notify}"
+    )
+
+
+def test_kri_conf_task_notifies_restart_salt_api():
+    """'Write kri salt-master configuration' must ALSO notify 'Restart salt-api'.
+
+    salt-api reads master.d at startup — an external_auth change in kri.conf
+    requires both services to restart or the new ACL will not take effect.
+    """
+    tasks = _load_yaml(_CONFIGURE_YML)
+    task = _find_task(tasks, "Write kri salt-master configuration")
+    assert task is not None, "'Write kri salt-master configuration' task not found in configure.yml"
+
+    notify = task.get("notify", [])
+    if isinstance(notify, str):
+        notify = [notify]
+    assert "Restart salt-api" in notify, (
+        "kri.conf template task must notify 'Restart salt-api' so that "
+        "external_auth ACL changes take effect without manual intervention; "
+        f"current notify list: {notify}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. handlers/main.yml: required handlers exist and use become + launchctl
+# ---------------------------------------------------------------------------
+
+
+def test_restart_salt_master_handler_exists():
+    handlers = _load_yaml(_HANDLERS_YML)
+    handler = _find_task(handlers, "Restart salt-master")
+    assert handler is not None, "'Restart salt-master' handler not found in handlers/main.yml"
+
+
+def test_restart_salt_master_handler_uses_become():
+    handlers = _load_yaml(_HANDLERS_YML)
+    handler = _find_task(handlers, "Restart salt-master")
+    assert handler is not None
+    assert handler.get("become") is True, "'Restart salt-master' handler must set become: true"
+
+
+def test_restart_salt_master_handler_uses_launchctl():
+    handlers = _load_yaml(_HANDLERS_YML)
+    handler = _find_task(handlers, "Restart salt-master")
+    assert handler is not None
+    shell_body = str(handler.get("shell", ""))
+    assert "launchctl" in shell_body, (
+        "'Restart salt-master' handler must use launchctl (macOS service manager)"
+    )
+
+
+def test_restart_salt_api_handler_exists():
+    handlers = _load_yaml(_HANDLERS_YML)
+    handler = _find_task(handlers, "Restart salt-api")
+    assert handler is not None, "'Restart salt-api' handler not found in handlers/main.yml"
+
+
+def test_restart_salt_api_handler_uses_become():
+    handlers = _load_yaml(_HANDLERS_YML)
+    handler = _find_task(handlers, "Restart salt-api")
+    assert handler is not None
+    assert handler.get("become") is True, "'Restart salt-api' handler must set become: true"
+
+
+def test_restart_salt_api_handler_uses_launchctl():
+    handlers = _load_yaml(_HANDLERS_YML)
+    handler = _find_task(handlers, "Restart salt-api")
+    assert handler is not None
+    shell_body = str(handler.get("shell", ""))
+    assert "launchctl" in shell_body, (
+        "'Restart salt-api' handler must use launchctl (macOS service manager)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. verify.yml: post-restart verification tasks exist
+# ---------------------------------------------------------------------------
+
+
+def test_verify_yml_waits_for_salt_api_port():
+    """verify.yml must contain a wait_for task that references salt_api_port (8080)."""
+    tasks = _load_yaml(_VERIFY_YML)
+    found = False
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        wf = task.get("wait_for", {})
+        if isinstance(wf, dict):
+            port_val = str(wf.get("port", ""))
+            if "salt_api_port" in port_val or port_val == "8080":
+                found = True
+                break
+        # Also check string-form wait_for (unusual but valid)
+        if "salt_api_port" in str(wf) or "8080" in str(wf):
+            found = True
+            break
+    assert found, (
+        "verify.yml must contain a wait_for task for port {{ salt_api_port }} (8080)"
+    )
+
+
+def test_verify_yml_waits_for_salt_master_port():
+    """verify.yml must contain a wait_for task for salt-master port 4505."""
+    tasks = _load_yaml(_VERIFY_YML)
+    found = False
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        wf = task.get("wait_for", {})
+        if isinstance(wf, dict) and str(wf.get("port", "")) == "4505":
+            found = True
+            break
+    assert found, "verify.yml must contain a wait_for task for port 4505 (salt-master ZMQ)"
+
+
+def test_verify_yml_has_login_readiness_probe():
+    """verify.yml must contain a uri task that POSTs to /login."""
+    raw_text = _VERIFY_YML.read_text()
+    assert "/login" in raw_text, (
+        "verify.yml must include a salt-api /login readiness probe (uri module POST /login)"
+    )
+
+
+def test_verify_yml_login_probe_is_skippable():
+    """The /login probe must be gated on salt_api_verify so it can be disabled."""
+    raw_text = _VERIFY_YML.read_text()
+    assert "salt_api_verify" in raw_text, (
+        "verify.yml /login probe must be conditioned on 'salt_api_verify' "
+        "so operators can skip it when kri_salt_api_password is not available"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. main.yml: verify.yml is included as the final task file
+# ---------------------------------------------------------------------------
+
+
+def test_main_yml_includes_verify():
+    """tasks/main.yml must import or include verify.yml."""
+    raw_text = _MAIN_YML.read_text()
+    assert "verify.yml" in raw_text, (
+        "tasks/main.yml must import_tasks or include_tasks verify.yml "
+        "so verification always runs after service startup"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. README.md: exists and documents become/sudo + re-apply command
+# ---------------------------------------------------------------------------
+
+
+def test_readme_exists():
+    assert _README_MD.exists(), f"README.md not found at {_README_MD}"
+
+
+def test_readme_documents_become_sudo():
+    """README must mention sudo/become so operators know the prerequisite."""
+    text = _README_MD.read_text()
+    assert "become" in text.lower() or "sudo" in text.lower(), (
+        "README.md must document the sudo/become prerequisite for running this role"
+    )
+
+
+def test_readme_documents_reapply_command():
+    """README must include the exact command to re-apply the role against mm1."""
+    text = _README_MD.read_text()
+    assert "ansible-playbook" in text, (
+        "README.md must include the exact ansible-playbook re-apply command for mm1"
+    )
+    assert "deploy_salt_master_mm1.yml" in text or "saltmaster install" in text, (
+        "README.md must reference deploy_salt_master_mm1.yml or 'scripts/kri saltmaster install'"
+    )


### PR DESCRIPTION
Closes #659. **Awaiting DK review — do not auto-merge.** Lets the already-provisioned mm1 receive the #641 salt-api `external_auth` ACL via Ansible `become` (sudo over SSH), no manual operator sudo.

## Changes (external Principal Ansible engineer)
- `tasks/configure.yml` — kri.conf change now notifies **both** `Restart salt-master` and `Restart salt-api` (external_auth needs a master restart to take effect; salt-api shares the eauth).
- `tasks/verify.yml` (new, imported last in main.yml) — `wait_for` 4505 (master) + `salt_api_port` (salt-api), then a **POST `/login` readiness probe** asserting HTTP 200 + token (proves the ACL/eauth is live). Skippable via `-e salt_api_verify=false`.
- `README.md` (new) — runbook: sudo/become prerequisite, exact re-apply command, variable table, ACL-sync note.
- 20 source-contract tests; all role YAML parses; ruff clean. (ansible-lint not in the venv — not run.)

## Re-apply command (from the README)
`scripts/kri saltmaster install 192.168.1.64` — or `ansible-playbook playbooks/deploy_salt_master_mm1.yml -i playbooks/inventory/hosts.ini -e "kri_salt_api_password=<pw>"`

## Please confirm in review (expert's flagged assumptions)
1. Passwordless sudo on mm1's `dk` account (else use `--ask-become-pass`).
2. `kri_salt_api_password` supplied at run time for the `/login` probe (or `-e salt_api_verify=false`).
3. **Linux parity out of scope** — handlers are macOS/launchctl only; mm1 is macOS. Linux systemd dual-notify can follow if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)