### PR TITLE
#639 P1 cleanups: dead-endpoint removal + collector TLS + hypertable segmentby

### DIFF
--- a/fleet_platform/api/routes/node_actions.py
+++ b/fleet_platform/api/routes/node_actions.py
@@ -205,28 +205,6 @@ async def request_node_action(
     )
 
 
-@router.get("/{node_id}/processes")
-async def list_processes(
-    node_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    _claims: dict = Depends(require_role("operator", "admin")),
-):
-    """List running processes on a node via Salt ps.list_processes."""
-    from sqlalchemy import select as _sel
-
-    node_result = await db.execute(_sel(Node).where(Node.id == node_id))
-    node = node_result.scalar_one_or_none()
-    if not node:
-        raise HTTPException(status_code=404, detail="Node not found")
-    from fleet_platform.workers.salt_tasks import run_salt_cmd
-
-    task = run_salt_cmd.delay(
-        function="ps.list_processes",
-        target_minions=[node.minion_id],
-        args=[],
-    )
-    return {"task_id": task.id, "minion_id": node.minion_id}
-
 
 @router.get("/{node_id}/services")
 async def list_services(

--- a/fleet_platform/db/migrations/versions/049_process_stats_compress_segmentby.py
+++ b/fleet_platform/db/migrations/versions/049_process_stats_compress_segmentby.py
@@ -1,0 +1,27 @@
+"""node_process_stats: add compress_segmentby=node_id
+
+Revision ID: 049
+Revises: 048
+Create Date: 2026-06-09
+"""
+
+from alembic import op
+
+revision = "049"
+down_revision = "048"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Changing segmentby requires compression be temporarily disabled on existing chunks.
+    # Decompress is implicit when altering; set both orderby+segmentby together.
+    op.execute(
+        "ALTER TABLE node_process_stats SET (timescaledb.compress_segmentby = 'node_id', timescaledb.compress_orderby = 'collected_at DESC')"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE node_process_stats SET (timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'collected_at DESC')"
+    )

--- a/salt/states/base/files/process_collector.py
+++ b/salt/states/base/files/process_collector.py
@@ -10,6 +10,17 @@ the pure classifier (is_llm_process) is importable without psutil present.
 
 Usage (invoked by process_report.sls):
     INGEST_URL=https://... NODE_TOKEN=... MINION_ID=<id> python3 process_collector.py
+
+TLS verification
+----------------
+By default the ingest POST verifies the server's TLS certificate using the
+system CA bundle.  When the Fleet Platform is served behind Traefik with a
+self-signed or internal certificate, verification must be disabled:
+
+    INGEST_TLS_VERIFY=false python3 process_collector.py ...
+
+Accepted falsy values: ``0``, ``false``, ``no`` (case-insensitive).
+Any other value (or the env var being absent) keeps verification enabled.
 """
 
 import json
@@ -171,6 +182,30 @@ def collect(top_n: int = 200) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# TLS helpers
+# ---------------------------------------------------------------------------
+
+
+def _ssl_context(verify: bool):
+    """Return an ssl.SSLContext appropriate for the requested verification mode.
+
+    Args:
+        verify: when True return None so urllib uses its default (system CA
+                bundle, full certificate verification).  When False return an
+                unverified context that accepts self-signed / internal certs.
+
+    Returns:
+        None (verify=True) or an ssl.SSLContext with CERT_NONE (verify=False).
+    """
+    if verify:
+        return None
+    import ssl  # noqa: PLC0415 — lazy import, matches psutil pattern
+
+    ctx = ssl._create_unverified_context()  # noqa: SLF001
+    return ctx
+
+
+# ---------------------------------------------------------------------------
 # Poster
 # ---------------------------------------------------------------------------
 
@@ -212,7 +247,13 @@ def post(
         method="POST",
     )
 
-    resp = urllib.request.urlopen(req, timeout=30)
+    verify = os.environ.get("INGEST_TLS_VERIFY", "true").lower() not in (
+        "0",
+        "false",
+        "no",
+    )
+    ctx = _ssl_context(verify)
+    resp = urllib.request.urlopen(req, timeout=30, context=ctx)
     return resp.status
 
 

--- a/tests/unit/test_collector_tls_639.py
+++ b/tests/unit/test_collector_tls_639.py
@@ -1,0 +1,149 @@
+"""
+Unit tests for TLS-verification support in process_collector — GitHub issue #639.
+
+Tests three concerns:
+  1. _ssl_context(True)  → None  (system default, full cert verification)
+  2. _ssl_context(False) → ssl.SSLContext with CERT_NONE (self-signed / internal certs)
+  3. Source-contract: post() reads INGEST_TLS_VERIFY and passes context= to urlopen
+
+No psutil required; the module is imported via importlib the same way as the
+existing test_process_collector_610.py so the lazy-import pattern is respected.
+"""
+
+import importlib.util
+import ssl
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the collector module by file path (no psutil needed)
+# ---------------------------------------------------------------------------
+
+_COLLECTOR_PATH = (
+    Path(__file__).parent.parent.parent
+    / "salt"
+    / "states"
+    / "base"
+    / "files"
+    / "process_collector.py"
+)
+
+
+def _load_collector():
+    spec = importlib.util.spec_from_file_location("process_collector", _COLLECTOR_PATH)
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture(scope="module")
+def collector():
+    return _load_collector()
+
+
+@pytest.fixture(scope="module")
+def collector_source():
+    return _COLLECTOR_PATH.read_text()
+
+
+# ---------------------------------------------------------------------------
+# _ssl_context — behavioural tests
+# ---------------------------------------------------------------------------
+
+
+class TestSslContext:
+    def test_verify_true_returns_none(self, collector):
+        """When verify=True the helper returns None so urllib uses its default."""
+        result = collector._ssl_context(True)
+        assert result is None
+
+    def test_verify_false_returns_ssl_context(self, collector):
+        """When verify=False the helper returns an ssl.SSLContext instance."""
+        ctx = collector._ssl_context(False)
+        assert isinstance(ctx, ssl.SSLContext)
+
+    def test_verify_false_cert_none(self, collector):
+        """The unverified context must have CERT_NONE so self-signed certs are accepted."""
+        ctx = collector._ssl_context(False)
+        assert ctx.verify_mode == ssl.CERT_NONE
+
+
+# ---------------------------------------------------------------------------
+# post() — source-contract checks
+# ---------------------------------------------------------------------------
+
+
+class TestPostSourceContract:
+    """Grep-level source-contract: post() must wire up INGEST_TLS_VERIFY + context=."""
+
+    def test_reads_ingest_tls_verify_env_var(self, collector_source):
+        """post() source must reference the INGEST_TLS_VERIFY env var."""
+        assert "INGEST_TLS_VERIFY" in collector_source
+
+    def test_passes_context_to_urlopen(self, collector_source):
+        """post() source must pass context= to urlopen."""
+        assert "context=ctx" in collector_source or "context=" in collector_source
+
+    def test_calls_ssl_context_helper(self, collector_source):
+        """post() source must call _ssl_context to build the context."""
+        assert "_ssl_context(" in collector_source
+
+    def test_falsy_env_values_documented(self, collector_source):
+        """The docstring / module body must list the accepted falsy values."""
+        assert '"false"' in collector_source or "'false'" in collector_source
+        assert '"no"' in collector_source or "'no'" in collector_source
+        assert '"0"' in collector_source or "'0'" in collector_source
+
+
+# ---------------------------------------------------------------------------
+# post() — behavioural: env var controls the context passed to urlopen
+# ---------------------------------------------------------------------------
+
+
+class TestPostTlsVerifyBehaviour:
+    """Verify that post() passes the right ssl context to urlopen based on env."""
+
+    def _make_mock_response(self):
+        resp = MagicMock()
+        resp.status = 200
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_tls_verify_true_by_default_passes_none_context(self, collector):
+        """With INGEST_TLS_VERIFY unset (default), context passed to urlopen is None."""
+        with patch.dict("os.environ", {}, clear=False):
+            # Remove the var if it happens to be set
+            import os
+
+            os.environ.pop("INGEST_TLS_VERIFY", None)
+            with patch("urllib.request.urlopen", return_value=self._make_mock_response()) as mock_open:
+                collector.post("https://example.com/api/v1/ingest", "tok", "minion1", [])
+        _args, kwargs = mock_open.call_args
+        assert kwargs.get("context") is None
+
+    def test_tls_verify_false_passes_ssl_context(self, collector):
+        """With INGEST_TLS_VERIFY=false, context passed to urlopen is an SSLContext."""
+        with patch.dict("os.environ", {"INGEST_TLS_VERIFY": "false"}):
+            with patch("urllib.request.urlopen", return_value=self._make_mock_response()) as mock_open:
+                collector.post("https://example.com/api/v1/ingest", "tok", "minion1", [])
+        _args, kwargs = mock_open.call_args
+        assert isinstance(kwargs.get("context"), ssl.SSLContext)
+
+    def test_tls_verify_zero_passes_ssl_context(self, collector):
+        """With INGEST_TLS_VERIFY=0, context is an SSLContext (falsy value)."""
+        with patch.dict("os.environ", {"INGEST_TLS_VERIFY": "0"}):
+            with patch("urllib.request.urlopen", return_value=self._make_mock_response()) as mock_open:
+                collector.post("https://example.com/api/v1/ingest", "tok", "minion1", [])
+        _args, kwargs = mock_open.call_args
+        assert isinstance(kwargs.get("context"), ssl.SSLContext)
+
+    def test_tls_verify_no_passes_ssl_context(self, collector):
+        """With INGEST_TLS_VERIFY=no, context is an SSLContext (falsy value)."""
+        with patch.dict("os.environ", {"INGEST_TLS_VERIFY": "no"}):
+            with patch("urllib.request.urlopen", return_value=self._make_mock_response()) as mock_open:
+                collector.post("https://example.com/api/v1/ingest", "tok", "minion1", [])
+        _args, kwargs = mock_open.call_args
+        assert isinstance(kwargs.get("context"), ssl.SSLContext)

--- a/tests/unit/test_dead_processes_endpoint_removed_639.py
+++ b/tests/unit/test_dead_processes_endpoint_removed_639.py
@@ -1,0 +1,41 @@
+"""
+Source-contract test for issue #639:
+Dead GET /{node_id}/processes endpoint removed from node_actions.py.
+The UI was rewired to GET /nodes/{id}/process_stats in #613;
+the old salt-dispatch route had no consumer and is now deleted.
+"""
+
+from pathlib import Path
+
+_ROUTES_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "fleet_platform"
+    / "api"
+    / "routes"
+    / "node_actions.py"
+)
+_SOURCE = _ROUTES_FILE.read_text()
+
+
+def test_list_processes_function_removed():
+    assert "def list_processes" not in _SOURCE, (
+        "list_processes must be removed from node_actions.py (#639)"
+    )
+
+
+def test_processes_route_decorator_removed():
+    assert '/{node_id}/processes"' not in _SOURCE, (
+        'GET /{node_id}/processes route decorator must be removed from node_actions.py (#639)'
+    )
+
+
+def test_list_services_still_present():
+    assert "def list_services" in _SOURCE, (
+        "list_services must NOT be removed — still used by the Services tab"
+    )
+
+
+def test_services_route_decorator_present():
+    assert '/{node_id}/services"' in _SOURCE, (
+        'GET /{node_id}/services route decorator must remain in node_actions.py'
+    )

--- a/tests/unit/test_segmentby_migration_049.py
+++ b/tests/unit/test_segmentby_migration_049.py
@@ -1,0 +1,68 @@
+"""Tests for migration 049: node_process_stats compress_segmentby=node_id.
+
+Verifies:
+  1. Module-level revision="049" and down_revision="048" are correct.
+  2. The migration text contains compress_segmentby and node_id.
+  3. The chain guard (test_migration_chain_guard_571) still passes with 049 in place.
+"""
+
+import ast
+from pathlib import Path
+
+VERSIONS = Path(__file__).resolve().parents[2] / "fleet_platform/db/migrations/versions"
+MIGRATION = VERSIONS / "049_process_stats_compress_segmentby.py"
+
+
+def _module_assignments(path: Path) -> dict:
+    """Return module-level simple name=constant assignments."""
+    tree = ast.parse(path.read_text())
+    out: dict = {}
+    for node in tree.body:
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            try:
+                out[node.targets[0].id] = ast.literal_eval(node.value)
+            except (ValueError, SyntaxError):
+                out[node.targets[0].id] = "<non-literal>"
+    return out
+
+
+def test_migration_049_module_level_revision():
+    assignments = _module_assignments(MIGRATION)
+    assert assignments.get("revision") == "049", (
+        f"expected revision='049', got {assignments.get('revision')!r}"
+    )
+    assert assignments.get("down_revision") == "048", (
+        f"expected down_revision='048', got {assignments.get('down_revision')!r}"
+    )
+
+
+def test_migration_049_contains_compress_segmentby_node_id():
+    text = MIGRATION.read_text()
+    assert "compress_segmentby" in text, "migration must reference compress_segmentby"
+    assert "node_id" in text, "migration must reference node_id as the segmentby column"
+
+
+def test_chain_still_linear_after_049():
+    """Inline the chain-guard logic so this test file is self-contained."""
+    files = sorted(p for p in VERSIONS.glob("*.py") if p.name != "__init__.py")
+    revs: dict = {}
+    for p in files:
+        a = _module_assignments(p)
+        revs[str(a.get("revision"))] = a.get("down_revision")
+
+    roots = [r for r, d in revs.items() if d is None]
+    assert len(roots) == 1, f"expected exactly one root migration, got {roots}"
+
+    known = set(revs)
+    dangling = [(r, d) for r, d in revs.items() if d is not None and d not in known]
+    assert not dangling, f"down_revision points to unknown revision(s): {dangling}"
+
+    parents = [d for d in revs.values() if d is not None]
+    dupes = {d for d in parents if parents.count(d) > 1}
+    assert not dupes, f"multiple migrations share a down_revision (branch/multiple heads): {dupes}"
+
+    assert "049" in known, "migration 049 not found in chain"


### PR DESCRIPTION
Three audit #639 P1 items: removes orphaned GET /nodes/{id}/processes (UI uses /process_stats since #613); adds INGEST_TLS_VERIFY + _ssl_context() to the collector (self-signed HTTPS ingest was failing); migration 049 sets node_process_stats compress_segmentby=node_id (per-node query perf). Behavioral/contract tests; full suite 2692 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)