### PR TITLE
fix(bootstrap): stop mislabeling salt-master gate failures as SSH unreachable (#992)

### DIFF
--- a/fleet_platform/workers/ansible_tasks.py
+++ b/fleet_platform/workers/ansible_tasks.py
@@ -77,6 +77,25 @@ def _format_ansible_cmdline(playbook: str, inventory: str, extravars: dict) -> s
     return f"── Ansible command ──────────────────────────────────────────\n$ {cmd}\n──────────────────────────────────────────────────────────────\n"
 
 
+def _classify_ansible_failure_category(full_stdout: str) -> str | None:
+    """Categorize an ansible failure from its stdout for human error messages.
+
+    Order matters: the salt-master reachability gate (host_prep_gate.yml) prints
+    the word "UNREACHABLE" in *debug* lines even though SSH itself succeeded, so
+    it must be checked BEFORE the SSH-unreachable marker. Real SSH-unreachable is
+    Ansible's host marker "UNREACHABLE!" (with the exclamation) or "unreachable=1"
+    in the PLAY RECAP — never the bare word (#992). Returns None when none match
+    so the caller keeps its own rc/status default.
+    """
+    if "Target cannot reach any salt-master" in full_stdout:
+        return "salt_master_gate"
+    if "Authentication failure" in full_stdout or "Permission denied" in full_stdout:
+        return "ssh_auth"
+    if "UNREACHABLE!" in full_stdout or "unreachable=1" in full_stdout:
+        return "ssh_unreachable"
+    return None
+
+
 @celery_app.task(
     name="fleet_platform.workers.ansible_tasks.bootstrap_node",
     bind=True,
@@ -441,9 +460,15 @@ def bootstrap_node(
                 f"Timed out after 10 minutes. Last task: {last_task}" if last_task else "Timed out after 10 minutes."
             )
         elif final_status != "successful" or runner.rc != 0:
-            if "Authentication failure" in full_stdout or "Permission denied" in full_stdout:
+            _cat = _classify_ansible_failure_category(full_stdout)
+            if _cat == "salt_master_gate":
+                bootstrap_error = (
+                    "SSH reached the node, but it cannot reach the salt-master on "
+                    "4505/4506 — check the master is running and reachable from this node"
+                )
+            elif _cat == "ssh_auth":
                 bootstrap_error = "SSH auth failed: check SSH username/password in Settings → Bootstrap"
-            elif "UNREACHABLE" in full_stdout:
+            elif _cat == "ssh_unreachable":
                 bootstrap_error = f"SSH unreachable: check IP {target_ip} and SSH credentials in Settings"
             elif "No such file or directory" in full_stdout and "salt" in full_stdout:
                 bootstrap_error = "Salt package not found on target node"
@@ -1098,9 +1123,15 @@ def provision_master(self, salt_master_id: str, action: str = "install") -> dict
                 else f"Timed out after {_prov_timeout_min} minutes."
             )
         elif final_status != "successful" or runner.rc != 0:
-            if "Authentication failure" in full_stdout or "Permission denied" in full_stdout:
+            _cat = _classify_ansible_failure_category(full_stdout)
+            if _cat == "salt_master_gate":
+                provision_error = (
+                    "SSH reached the master node, but it cannot reach a salt-master on "
+                    "4505/4506 — check network/firewall"
+                )
+            elif _cat == "ssh_auth":
                 provision_error = "SSH auth failed: check SSH username/password on the master record"
-            elif "UNREACHABLE" in full_stdout:
+            elif _cat == "ssh_unreachable":
                 provision_error = f"SSH unreachable: check ssh_host ({ssh_host}) and SSH credentials"
             else:
                 provision_error = f"ansible rc={rc_display} status={final_status}"

--- a/tests/unit/test_bootstrap_error_classification_992.py
+++ b/tests/unit/test_bootstrap_error_classification_992.py
@@ -1,0 +1,53 @@
+"""Regression tests for #992: bootstrap gate failures mislabeled as SSH unreachable.
+
+The salt-master reachability gate (host_prep_gate.yml) prints the bare word
+"UNREACHABLE" in its Ansible debug output even when SSH itself succeeded. The
+classifier must distinguish that from a real SSH-unreachable failure, which is
+signalled by Ansible's own "UNREACHABLE!" host marker or "unreachable=1" in the
+PLAY RECAP.
+"""
+
+from fleet_platform.workers.ansible_tasks import _classify_ansible_failure_category
+
+
+def test_gate_failure_is_not_ssh_unreachable():
+    """The regression case for #992: SSH worked, only the salt-master gate failed."""
+    stdout = (
+        "TASK [debug] ***\n"
+        "ok: [node1] => {\n"
+        '    "msg": "Master 192.168.1.64 (probed via 127.0.0.1) port 4505: UNREACHABLE"\n'
+        "}\n"
+        "FAILED! => {\n"
+        '    "msg": "Target cannot reach any salt-master on 4505/4506"\n'
+        "}\n"
+    )
+    assert _classify_ansible_failure_category(stdout) == "salt_master_gate"
+
+
+def test_real_ssh_unreachable_host_marker():
+    stdout = "fatal: [host]: UNREACHABLE! => {\"changed\": false, \"msg\": \"...\"}\n"
+    assert _classify_ansible_failure_category(stdout) == "ssh_unreachable"
+
+
+def test_real_ssh_unreachable_recap():
+    stdout = "PLAY RECAP ***\nhost : ok=0 changed=0 unreachable=1 failed=0\n"
+    assert _classify_ansible_failure_category(stdout) == "ssh_unreachable"
+
+
+def test_auth_failure():
+    stdout = "fatal: [host]: FAILED! => {\"msg\": \"Permission denied (publickey,password)\"}\n"
+    assert _classify_ansible_failure_category(stdout) == "ssh_auth"
+
+
+def test_clean_stdout_returns_none():
+    stdout = "PLAY RECAP ***\nhost : ok=5 changed=2 unreachable=0 failed=1\n"
+    assert _classify_ansible_failure_category(stdout) is None
+
+
+def test_gate_wins_over_real_unreachable_marker():
+    """Ordering guard: gate marker must be checked before the SSH markers."""
+    stdout = (
+        "Target cannot reach any salt-master on 4505/4506\n"
+        "fatal: [host]: UNREACHABLE! => {\"msg\": \"...\"}\n"
+    )
+    assert _classify_ansible_failure_category(stdout) == "salt_master_gate"


### PR DESCRIPTION
Closes #992. The bootstrap error banner showed 'SSH unreachable' when SSH actually worked (unreachable=0) and the real failure was the salt-master reachability gate. Classifier now distinguishes the gate message and the real Ansible UNREACHABLE! marker. 6 new unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)