### PR TITLE
fix(perf): run blocking git-clone + urlopen off the event loop in async routes (#999)

### DIFF
--- a/fleet_platform/api/routes/agent.py
+++ b/fleet_platform/api/routes/agent.py
@@ -17,6 +17,7 @@ email, so the agent can never act as a confused deputy.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -329,7 +330,7 @@ async def diff_artifact(
     live_content: str | None = None
     if target:
         playbooks_dir = await get_playbooks_dir(db)
-        roots = [d.resolve() for d in get_all_playbook_dirs(None, playbooks_dir)]
+        roots = [d.resolve() for d in await asyncio.to_thread(get_all_playbook_dirs, None, playbooks_dir)]
         candidate = (Path(playbooks_dir) / target).resolve()
         if any(candidate.is_relative_to(r) for r in roots) and candidate.is_file():
             live_content = candidate.read_text(errors="replace")
@@ -482,7 +483,7 @@ async def promote_artifact(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
     playbooks_dir = await get_playbooks_dir(db)
-    roots = [d.resolve() for d in get_all_playbook_dirs(None, playbooks_dir)]
+    roots = [d.resolve() for d in await asyncio.to_thread(get_all_playbook_dirs, None, playbooks_dir)]
     dest = (Path(playbooks_dir) / target).resolve()
     # Promotion target must stay inside an allowed playbook root.
     if not any(dest.is_relative_to(r) for r in roots):

--- a/fleet_platform/api/routes/ansible/files.py
+++ b/fleet_platform/api/routes/ansible/files.py
@@ -1,6 +1,7 @@
 # fleet_platform/api/routes/ansible/files.py
 """Playbook file management routes: /files/..."""
 
+import asyncio
 from pathlib import Path
 
 from fastapi import Body, Depends, HTTPException, Query
@@ -72,7 +73,7 @@ async def get_playbook_file(
     setting = result.scalar_one_or_none()
     sources_json = setting.value if setting else None
 
-    all_dirs = get_all_playbook_dirs(sources_json, _PLAYBOOKS_DIR)
+    all_dirs = await asyncio.to_thread(get_all_playbook_dirs, sources_json, _PLAYBOOKS_DIR)
     allowed_roots = [str(d.resolve()) for d in all_dirs]
 
     # Resolve: if path is relative, use source_dir or builtin dir as base
@@ -107,7 +108,7 @@ async def update_playbook_file(
     setting = result.scalar_one_or_none()
     sources_json = setting.value if setting else None
 
-    all_dirs = get_all_playbook_dirs(sources_json, _PLAYBOOKS_DIR)
+    all_dirs = await asyncio.to_thread(get_all_playbook_dirs, sources_json, _PLAYBOOKS_DIR)
     allowed_roots = [str(d.resolve()) for d in all_dirs]
 
     # Resolve: if path is relative, use source_dir or builtin dir as base

--- a/fleet_platform/api/routes/ansible/playbooks.py
+++ b/fleet_platform/api/routes/ansible/playbooks.py
@@ -1,6 +1,7 @@
 # fleet_platform/api/routes/ansible/playbooks.py
 """Playbook routes: /playbooks/..."""
 
+import asyncio
 import uuid
 from pathlib import Path
 
@@ -62,7 +63,7 @@ async def list_playbooks(
         # rows but all disabled" (catalog_total > 0, enabled empty).
         # Previously guarded by catalog_total == 0 which silently returned []
         # when all entries were disabled — fixed by always falling back here.
-        all_dirs_legacy = get_all_playbook_dirs(sources_json, _PLAYBOOKS_DIR)
+        all_dirs_legacy = await asyncio.to_thread(get_all_playbook_dirs, sources_json, _PLAYBOOKS_DIR)
         legacy_entries = []
         for d in all_dirs_legacy:
             for e in discover_all(d):
@@ -206,7 +207,7 @@ async def get_playbook_tree(
     if source_dir:
         playbooks_dir = Path(source_dir)
     else:
-        all_dirs = get_all_playbook_dirs(sources_json, _PLAYBOOKS_DIR)
+        all_dirs = await asyncio.to_thread(get_all_playbook_dirs, sources_json, _PLAYBOOKS_DIR)
         playbooks_dir = next(
             (d for d in all_dirs if (d / filename).exists() or (d / "roles" / filename.replace("roles/", "")).is_dir()),
             _PLAYBOOKS_DIR,
@@ -364,7 +365,7 @@ async def run_playbook_endpoint(
     _sources_setting = await db.execute(select(PlatformSetting).where(PlatformSetting.key == "playbook_sources"))
     _sources_row = _sources_setting.scalar_one_or_none()
     _sources_json = _sources_row.value if _sources_row else None
-    _all_dirs = get_all_playbook_dirs(_sources_json, _PLAYBOOKS_DIR)
+    _all_dirs = await asyncio.to_thread(get_all_playbook_dirs, _sources_json, _PLAYBOOKS_DIR)
     entry = None
     for _dir in _all_dirs:
         _found = next((e for e in discover_all(_dir) if e.filename == payload.playbook), None)

--- a/fleet_platform/services/ios_tracking_svc.py
+++ b/fleet_platform/services/ios_tracking_svc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import urllib.request
 import uuid
@@ -49,9 +50,13 @@ async def check_jenkins_agent(agent_id: uuid.UUID, db: AsyncSession) -> None:
 
     try:
         url = f"{agent.jenkins_url.rstrip('/')}/computer/{agent.agent_name}/api/json?tree=offline"
-        req = urllib.request.Request(url, method="GET")
-        with urllib.request.urlopen(req, timeout=5) as resp:  # nosec B310
-            data = json.loads(resp.read())
+
+        def _fetch() -> dict:
+            req = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(req, timeout=5) as resp:  # nosec B310
+                return json.loads(resp.read())
+
+        data = await asyncio.to_thread(_fetch)
         if data.get("offline") is False:
             agent.status = "online"
         else:

--- a/tests/unit/test_async_blockers_999.py
+++ b/tests/unit/test_async_blockers_999.py
@@ -1,0 +1,111 @@
+"""Source-contract tests for async-event-loop-blocking fixes (#999).
+
+Confirmed bug class (same as the merged salt_keys.py asyncio.to_thread fix):
+
+A2 — ``get_all_playbook_dirs`` (fleet_platform/services/playbook_sources.py) is a
+sync function that may git-clone (blocking subprocess.run with timeout=60). Every
+call site that sits directly inside an ``async def`` FastAPI route handler must be
+wrapped in ``await asyncio.to_thread(get_all_playbook_dirs, ...)``.
+
+A3 — ``check_jenkins_agent`` (fleet_platform/services/ios_tracking_svc.py) is
+``async def`` but previously called ``urllib.request.urlopen(..., timeout=5)``
+directly on the event loop. The blocking call must be moved into a sync inner
+function invoked via ``await asyncio.to_thread(...)``.
+
+All paths are resolved relative to this file's location (never absolute), so the
+tests work regardless of cwd.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Route files where every get_all_playbook_dirs() call site sits inside an
+# `async def` handler and was wrapped in asyncio.to_thread.
+WRAPPED_ROUTE_FILES = [
+    REPO_ROOT / "fleet_platform" / "api" / "routes" / "ansible" / "playbooks.py",
+    REPO_ROOT / "fleet_platform" / "api" / "routes" / "ansible" / "files.py",
+    REPO_ROOT / "fleet_platform" / "api" / "routes" / "agent.py",
+]
+
+# Expected number of `get_all_playbook_dirs(` call sites (any form) per file —
+# used to make sure every occurrence is the wrapped (to_thread) form, not just
+# "at least one".
+EXPECTED_CALL_COUNTS = {
+    "playbooks.py": 3,
+    "files.py": 2,
+    "agent.py": 2,
+}
+
+IOS_TRACKING_SVC = REPO_ROOT / "fleet_platform" / "services" / "ios_tracking_svc.py"
+
+
+def _text(path: Path) -> str:
+    assert path.is_file(), f"expected file not found: {path}"
+    return path.read_text()
+
+
+def test_wrapped_route_files_exist():
+    for path in WRAPPED_ROUTE_FILES:
+        assert path.is_file(), f"missing expected route file: {path}"
+
+
+def test_every_edited_route_file_imports_asyncio():
+    for path in WRAPPED_ROUTE_FILES:
+        text = _text(path)
+        assert "import asyncio" in text, f"{path} missing 'import asyncio'"
+
+
+def test_every_edited_route_file_wraps_get_all_playbook_dirs():
+    for path in WRAPPED_ROUTE_FILES:
+        text = _text(path)
+        assert "await asyncio.to_thread(get_all_playbook_dirs" in text, (
+            f"{path} does not contain a to_thread-wrapped get_all_playbook_dirs call"
+        )
+
+
+def test_no_unwrapped_get_all_playbook_dirs_calls_remain():
+    """A wrapped call looks like ``asyncio.to_thread(get_all_playbook_dirs, ...)``
+    — the function name is passed *by reference*, so it is never immediately
+    followed by its own '('. A bare, un-awaited call site (the old bug) always
+    looks like ``get_all_playbook_dirs(...)``. Assert zero of the bare form
+    remain in the fixed route files."""
+    for path in WRAPPED_ROUTE_FILES:
+        text = _text(path)
+        bare_call_count = text.count("get_all_playbook_dirs(")
+        assert bare_call_count == 0, (
+            f"{path}: found {bare_call_count} un-awaited get_all_playbook_dirs( call(s)"
+        )
+
+
+def test_wrapped_call_count_matches_expected():
+    for path in WRAPPED_ROUTE_FILES:
+        text = _text(path)
+        wrapped_count = text.count("asyncio.to_thread(get_all_playbook_dirs")
+        expected = EXPECTED_CALL_COUNTS[path.name]
+        assert wrapped_count == expected, (
+            f"{path}: expected {expected} to_thread-wrapped call sites, found {wrapped_count}"
+        )
+
+
+def test_ios_tracking_svc_wraps_blocking_urlopen():
+    text = _text(IOS_TRACKING_SVC)
+    assert "import asyncio" in text
+    assert "asyncio.to_thread(" in text
+
+
+def test_ios_tracking_svc_check_jenkins_agent_still_async():
+    text = _text(IOS_TRACKING_SVC)
+    assert "async def check_jenkins_agent(" in text
+
+
+def test_playbook_library_call_site_intentionally_not_wrapped():
+    """fleet_platform/api/routes/playbook_library.py line ~64 sits inside the
+    sync helper `_dir_source_pairs` (a plain `def`, not `async def`), so it
+    cannot be awaited without first making that helper async — out of scope
+    for this fix. Document that it remains unwrapped."""
+    path = REPO_ROOT / "fleet_platform" / "api" / "routes" / "playbook_library.py"
+    text = _text(path)
+    assert "def _dir_source_pairs(" in text
+    assert "async def _dir_source_pairs(" not in text
+    assert "all_dirs = get_all_playbook_dirs(sources_json, _PLAYBOOKS_DIR)" in text


### PR DESCRIPTION
Closes #999. A2: get_all_playbook_dirs git-clone (Playbooks/Files tabs freeze up to 60s) + A3: ios_tracking urlopen — both wrapped in asyncio.to_thread. 8 unit tests. One sync-helper call site (playbook_library.py) documented as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)